### PR TITLE
This is against the spec

### DIFF
--- a/src/Jackalope/Transaction/UserTransaction.php
+++ b/src/Jackalope/Transaction/UserTransaction.php
@@ -137,7 +137,6 @@ class UserTransaction implements \PHPCR\Transaction\UserTransactionInterface
 
         $this->transport->rollbackTransaction();
         $this->inTransaction = false;
-        $this->session->clear();
     }
 
     /**


### PR DESCRIPTION
node from the spec:
"Note, however, that changes made in the transient storage are not recorded by a transaction. This means that a rollback will not revert changes made to the transient storage of the Session. After a rollback the Session object state will still contain any pending changes that were present before the rollback."
