### PR TITLE
fixes call to logout

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -263,7 +263,7 @@ class Client implements TransactionalTransportInterface
     // inherit all doc
     public function logout()
     {
-        if (false !== $this->curl) {
+        if (!empty($this->curl)) {
             $this->curl->close();
         }
         $this->curl = false;


### PR DESCRIPTION
the $this-curl property can be null or false so a 
check for !empty seems more pertinents
