### PR TITLE
Matches processes with a '-jar' option in the getServerPid function

### DIFF
--- a/src/Jackalope/Tools/Console/Helper/JackrabbitHelper.php
+++ b/src/Jackalope/Tools/Console/Helper/JackrabbitHelper.php
@@ -58,7 +58,7 @@ class JackrabbitHelper
 
     public function getServerPid()
     {
-        $pid = trim(shell_exec("pgrep -f -n {$this->jackrabbit_jar}"));
+        $pid = trim(shell_exec("pgrep -f -n '\-jar {$this->jackrabbit_jar}'"));
         //TODO: check it's a valid pid
         return $pid;
     }


### PR DESCRIPTION
Ensures the matched process in the getServerPid function is not the php command that starts/stops the server using the jackrabbit_jar option.

If you run the command jackalope:run:jackrabbit with the jackrabbit_jar options, pgrep will match the php process of the command itself, and if you attempt to stop the server, on the stopServer function, the killed process will be the php command.
