### PR TITLE
added isMoved() and propagate path changes to properties

### DIFF
--- a/src/Jackalope/Item.php
+++ b/src/Jackalope/Item.php
@@ -169,9 +169,6 @@ abstract class Item implements ItemInterface
                 return;
             }
             $this->oldPath = $this->path;
-            // set this node to modified. this will result in a no-op on save
-            // but we need to have confirmSaved called so we remove oldPath
-            $this->setModified();
         }
         $this->path = $path;
         $this->depth = $path === '/' ? 0 : substr_count($path, '/');
@@ -286,6 +283,16 @@ abstract class Item implements ItemInterface
     {
         return self::STATE_MODIFIED === $this->state
             || self::STATE_DIRTY === $this->state && self::STATE_MODIFIED === $this->postDirtyState;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @private
+     */
+    public function isMoved()
+    {
+        return isset($this->oldPath);
     }
 
     /**

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -802,7 +802,7 @@ class ObjectManager
         }
         if (isset($this->objectsByPath['Node'])) {
             foreach ($this->objectsByPath['Node'] as $item) {
-                if ($item->isModified()) {
+                if ($item->isModified() || $item->isMoved()) {
                     $item->confirmSaved();
                 }
             }
@@ -1184,6 +1184,11 @@ class ObjectManager
                     }
                 }
                 if (isset($this->objectsByPath['Node'][$path])) {
+                    if ($item instanceof Node) {
+                        foreach ($item->getProperties() as $property) {
+                            $property->setPath($newItemPath.'/'.basename($property->getPath()), true);
+                        }
+                    }
                     $item = $this->objectsByPath['Node'][$path];
                     $this->objectsByPath['Node'][$newItemPath] = $item;
                     unset($this->objectsByPath['Node'][$path]);


### PR DESCRIPTION
Rather than piggy bank on isModified(), I rather introduced an isMoved() to determine if confirmSaved() should be called or not .. furthermore I am not propagating the path change to properties. However before we merge this test, we actually need to create a failing test case.
