### PR TITLE
Don't do a WeakReference de-reference on session->save()

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -778,7 +778,11 @@ class ObjectManager
                         }
 
                     } elseif ($item instanceof PropertyInterface) {
-                        if ($item->getValue() === null) {
+                        if ($item->isDeleted()) {
+                            $this->transport->deleteProperty($path);
+                        //FIXME: isDeleted should work for all property types. Not sure, if it actually does
+                        // This "else if" line could be removed, if all do
+                        } else if ($item->getType() != \PHPCR\PropertyType::WEAKREFERENCE && $item->getValue() === null) {
                             $this->transport->deleteProperty($path);
                         } else {
                             $this->transport->storeProperty($item);


### PR DESCRIPTION
Helps making less requests to Jackrabbit and helps avoiding the "CPU on 100%" issue on save() (which is actually a jackrabbit issue, but the call was unneeded)

There's a FIXME. If we're sure that every time we delete a property $property->isDeleted() returns the correct answer, we can get rid of the second "else if". I'm not sure, if this is the case
