### PR TITLE
Added ObjectManager->finishSave() to be called after all save operations...

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -793,11 +793,8 @@ class ObjectManager
                 }
             }
         }
-        
-        if (method_exists($this->transport, "finishSave")) {
-            $this->transport->finishSave();
-        }
 
+        $this->transport->finishSave();
 
         //clear those lists before reloading the newly added nodes from backend, to avoid collisions
         $this->itemsRemove = array();

--- a/src/Jackalope/Transport/WritingInterface.php
+++ b/src/Jackalope/Transport/WritingInterface.php
@@ -181,5 +181,14 @@ interface WritingInterface extends TransportInterface
      * @param string $prefix The prefix to unregister.
      */
     function unregisterNamespace($prefix);
+    
+    /**
+     * Called after everything internally is done in the save() method
+     *  so the transport has a chance to do final stuff (or commit everything at once)
+     *
+     * @return void
+     */
+    
+     function finishSave() 
 
 }


### PR DESCRIPTION
... are done

Added 3rd parameter to ObjectManager->moveNode() to move node immediately

Needed for JSOP support, which I will send a PR later. It does send all the save operations in one http request, so it needs to know, when all operations are done internally.

the finishSave method could also be an interface, but not sure, if that's worth it
