### PR TITLE
Return JCR_SQL2 instead of JCR_JQOM in getLanguage of the QueryObjectModel

### DIFF
--- a/src/Jackalope/Query/QOM/QueryObjectModel.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModel.php
@@ -142,6 +142,6 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
      */
     public function getLanguage()
     {
-        return self::JCR_JQOM;
+        return self::JCR_SQL2;
     }
 }


### PR DESCRIPTION
```
From the specs:
```

String Query.getLanguage()

returns the language in which the query is specified. 

If the Query was created with an explicitly supplied language string parameter using QueryManager.createQuery then this method returns that string.

If the Query is actually a QueryObjectModel created with QueryObjectModelFactory.createQuery then Query.getLanguage will return the string constant Query.JCR_SQL2.

See also https://github.com/phpcr/phpcr-api-tests/pull/63
