### PR TITLE
Ordering fix

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -269,7 +269,7 @@ class ObjectManager
         }
 
         if (!empty($fetchPaths)) {
-            $data = $this->transport->getNodes($fetchPaths, $class);        
+            $data = $this->transport->getNodes($fetchPaths);        
             $dataItems = array();
 
             foreach ($data as $fetchPath => $item) {


### PR DESCRIPTION
As I undertstand it, the object manager shouldn't worry about sort order, but if it doesn't at least return nodes in a predictable order then that will make other things more complicated.

This pr just ensures it returns nodes from getNodesByPath in the same order that they are requested, and as a result it fixes the broken ch23 tests and will resolve a number of the bugs reported about nodes appearing in unexpected order.
