### PR TITLE
Multiple operations fail because nodes originalNodesOrder is out of sync

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1216,9 +1216,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
         unset($this->nodes[$key]);
 
-        if (null === $this->originalNodesOrder) {
-            $this->originalNodesOrder = $this->nodes;
-        } else {
+        if (null !== $this->originalNodesOrder) {
             $this->originalNodesOrder = array_flip($this->originalNodesOrder);
             unset($this->originalNodesOrder[$name]);
             $this->originalNodesOrder = array_flip($this->originalNodesOrder);            
@@ -1252,9 +1250,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
         $this->nodes[] = $name;
         
-        if (null === $this->originalNodesOrder) {
-            $this->originalNodesOrder = $this->nodes;
-        } else {
+        if (null !== $this->originalNodesOrder) {
             $this->originalNodesOrder[] = $name;            
         }
     }


### PR DESCRIPTION
The nodes `getOrderCommands()` relies on comparing `originalNodesOrder` (which is set when a sessions first reorder operation happens) with the current state as found in the nodes `getNodes()`.

If the state of the tree is changed due to nodes being added, removed, or moved, in between reorder and saving the session, then things can go wrong as `originalNodesOrder` has the wrong number of elements, and unexpected elements / missing elements.

Because the reorder operation is the last operation in object managers `save()` method, then as long as we keep `originalNodesOrder` in sync with the adds and deletes, the reorder can then work as it should.  

The new test in phpcr-api-tests pr 69  (https://github.com/phpcr/phpcr-api-tests/pull/69) passes with this PR.
