### PR TITLE
remove jackalope-transport requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "php": ">=5.3.2",
         "phpcr/phpcr-utils": ">=1.0-beta3",
         "phpcr/phpcr": ">=2.1.0-beta3",
-        "ext-libxml": "*",
-        "jackalope/jackalope-transport": "1.0.*"
+        "ext-libxml": "*"
     },
     "provide": {
         "phpcr/phpcr-implementation": "2.1.0-beta4"


### PR DESCRIPTION
I don't think this is necessary (anymore)
