### PR TITLE
Fix for moving nodes already in memory

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -1182,7 +1182,7 @@ class ObjectManager
         // propagate to current and children items of $curPath, updating internal path
         foreach ($this->objectsByPath['Node'] as $path => $item) {
             // is it current or child?
-            if (strpos($path, $curPath) === 0) {
+            if ((strpos($path, $curPath . '/') === 0)||($path == $curPath)) {
                 // curPath = /foo
                 // newPath = /mo
                 // path    = /foo/bar


### PR DESCRIPTION
Fixes bug demonstrated by this new test phpcr/phpcr-api-tests#71 - where nodes are already in memory, similar named siblings can be moved by accident.
