### PR TITLE
adjust for https://github.com/phpcr/phpcr/pull/54

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1092,7 +1092,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      *
      * @api
      */
-    public function setMixins($mixinNames)
+    public function setMixins(array $mixinNames)
     {
         $toRemove = array();
         if ($this->hasProperty('jcr:mixinTypes')) {


### PR DESCRIPTION
if we do https://github.com/phpcr/phpcr/pull/54 we should afterwards tag a new version and require that from jackalope to avoid inconsistencies.
