### PR TITLE
Fixed caching of linear versions

### DIFF
--- a/src/Jackalope/Version/VersionHistory.php
+++ b/src/Jackalope/Version/VersionHistory.php
@@ -241,5 +241,6 @@ class VersionHistory extends Node implements VersionHistoryInterface
     public function notifyHistoryChanged()
     {
         $this->versions = null;
+        $this->linearVersions = null;
     }
 }


### PR DESCRIPTION
As discussed here:
https://github.com/phpcr/phpcr-api-tests/pull/84

This PR should hopefully fix this issue where versions are cleared from the cache, but not linear versions.

I ran the phpcr-api-tests and it doesn't appear to cause any regressions, and does fix the test in the PR above (unfortunately on my machine I get 7 failures already, before applying the above test or the above fix).
