### PR TITLE
refactor to allow transport to have efficient getNode(s)ByIdentifier

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -349,7 +349,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
             $newName = PathHelper::getNodeName($relPath);
 
             try {
-                $parentNode = $this->objectManager->getNode($parentPath);
+                $parentNode = $this->objectManager->getNodeByPath($parentPath);
             } catch (ItemNotFoundException $e) {
                 //we have to throw a different exception if there is a property
                 // with that name than if there is nothing at the path at all.

--- a/src/Jackalope/Query/NodeIterator.php
+++ b/src/Jackalope/Query/NodeIterator.php
@@ -75,7 +75,7 @@ class NodeIterator implements SeekableIterator, Countable
             return null;
         }
 
-        return $this->objectmanager->getNode($path);
+        return $this->objectmanager->getNodeByPath($path);
     }
 
     public function key()

--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -162,7 +162,7 @@ class Row implements Iterator, RowInterface
      */
     public function getNode($selectorName = null)
     {
-        return $this->objectmanager->getNode($this->getPath($selectorName));
+        return $this->objectmanager->getNodeByPath($this->getPath($selectorName));
     }
 
     /**

--- a/src/Jackalope/Session.php
+++ b/src/Jackalope/Session.php
@@ -214,7 +214,7 @@ class Session implements SessionInterface
      */
     public function getNodeByIdentifier($id)
     {
-        return $this->objectManager->getNode($id);
+        return $this->objectManager->getNodeByIdentifier($id);
     }
 
     /**
@@ -228,13 +228,8 @@ class Session implements SessionInterface
             $hint = is_object($ids) ? get_class($ids) : gettype($ids);
             throw new InvalidArgumentException("Not a valid array or Traversable: $hint");
         }
-        $nodesByPath = $this->objectManager->getNodes($ids);
-        $nodesByUUID = array();
-        foreach ($nodesByPath as $node) {
-            $nodesByUUID[$node->getIdentifier()] = $node;
-        }
 
-        return new ArrayIterator($nodesByUUID);
+        return $this->objectManager->getNodesByIdentifier($ids);
     }
 
     /**

--- a/src/Jackalope/Transport/TransportInterface.php
+++ b/src/Jackalope/Transport/TransportInterface.php
@@ -184,12 +184,29 @@ interface TransportInterface
      *
      * @param array $path Absolute paths to the nodes.
      *
-     * @return array associative array for the node (decoded from json with
-     *      associative = true)
+     * @return array keys are the absolute paths, values is the node data as
+     *      associative array (decoded from json with associative = true)
      *
      * @throws \PHPCR\RepositoryException if not logged in
      */
     public function getNodes($paths);
+
+    /**
+     * Get the nodes from an array of uuid.
+     *
+     * This is an optimization over getNodeByIdentifier to get many nodes in
+     * one call. If the transport implementation does not optimize, it can just
+     * loop over the uuids and call getNodeByIdentifier repeatedly.
+     *
+     * @param array $identifiers list of uuid to retreive
+     *
+     * @return array keys are the absolute paths, values is the node data as
+     *      associative array (decoded from json with associative = true). they
+     *      will have the identifier value set.
+     *
+     * @throws \PHPCR\RepositoryException if not logged in
+     */
+    public function getNodesByIdentifier($identifiers);
 
     /**
      * Get the property stored at an absolute path.
@@ -207,17 +224,19 @@ interface TransportInterface
     public function getProperty($path);
 
     /**
-     * Get the node path from a JCR uuid
+     * Get the node from a uuid. Same data format as getNode, but additionally
+     * must have the :jcr:path property.
      *
      * @param string $uuid the id in JCR format
      *
-     * @return string Absolute path to the node (not the node itself!)
+     * @return array associative array for the node (decoded from json with
+     *      associative = true)
      *
      * @throws \PHPCR\ItemNotFoundException if the backend does not know the
      *      uuid
      * @throws \PHPCR\RepositoryException if not logged in
      */
-    public function getNodePathForIdentifier($uuid);
+    public function getNodeByIdentifier($uuid);
 
     /**
      * Retrieve a stream of a binary property value

--- a/src/Jackalope/Version/Version.php
+++ b/src/Jackalope/Version/Version.php
@@ -52,7 +52,7 @@ class Version extends Node implements VersionInterface
         }
         $uuid = reset($successors);
 
-        return $this->objectManager->getNode($uuid, '/', 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
     }
 
     /**
@@ -70,7 +70,7 @@ class Version extends Node implements VersionInterface
         $results = array();
         foreach ($successors as $uuid) {
             // OPTIMIZE: use objectManager->getNodes instead of looping
-            $results[] = $this->objectManager->getNode($uuid, '/', 'Version\\Version');
+            $results[] = $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
         }
 
         return $results;
@@ -94,7 +94,7 @@ class Version extends Node implements VersionInterface
         }
         $uuid = reset($predecessor);
 
-        return $this->objectManager->getNode($uuid, '/', 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
     }
 
     /**
@@ -113,7 +113,7 @@ class Version extends Node implements VersionInterface
         $results = array();
         foreach ($predecessors as $uuid) {
             // OPTIMIZE: use objectManager->getNodes instead of looping
-            $results[] = $this->objectManager->getNode($uuid, '/', 'Version\\Version');
+            $results[] = $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
         }
 
         return $results;

--- a/src/Jackalope/Version/VersionManager.php
+++ b/src/Jackalope/Version/VersionManager.php
@@ -103,7 +103,7 @@ class VersionManager implements VersionManagerInterface
      */
     public function isCheckedOut($absPath)
     {
-        $node = $this->objectManager->getNode($absPath);
+        $node = $this->objectManager->getNodeByPath($absPath);
         if (! $node->isNodeType('mix:simpleVersionable')) {
             throw new UnsupportedRepositoryOperationException("Node at $absPath is not versionable");
         }
@@ -118,12 +118,12 @@ class VersionManager implements VersionManagerInterface
      */
     public function getVersionHistory($absPath)
     {
-        $node = $this->objectManager->getNode($absPath);
+        $node = $this->objectManager->getNodeByPath($absPath);
         if (! $node->isNodeType('mix:simpleVersionable')) {
             throw new UnsupportedRepositoryOperationException("Node at $absPath is not versionable");
         }
 
-        return $this->objectManager->getNode($node->getProperty('jcr:versionHistory')->getString(), '/', 'Version\\VersionHistory');
+        return $this->objectManager->getNodeByIdentifier($node->getProperty('jcr:versionHistory')->getString(), 'Version\\VersionHistory');
     }
 
     /**
@@ -141,7 +141,7 @@ class VersionManager implements VersionManagerInterface
             throw new UnsupportedRepositoryOperationException("No jcr:baseVersion version for $absPath");
         }
 
-        return $this->objectManager->getNode($uuid, '/', 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
     }
 
     /**
@@ -176,7 +176,7 @@ class VersionManager implements VersionManagerInterface
 
         } elseif ($version instanceof VersionInterface) {
             $versionPath = $version->getPath();
-            $nodePath = $this->objectManager->getNode($version->getContainingHistory()->getVersionableIdentifier())->getPath();
+            $nodePath = $this->objectManager->getNodeByIdentifier($version->getContainingHistory()->getVersionableIdentifier())->getPath();
 
         } else {
             throw new InvalidArgumentException();

--- a/tests/Jackalope/ObjectManagerTest.php
+++ b/tests/Jackalope/ObjectManagerTest.php
@@ -14,7 +14,7 @@ class ObjectManagerTest extends TestCase
         $children = $node->getNodes();
         $this->assertInstanceOf('Iterator', $children);
         $this->assertSame(2, count($children));
-        $this->assertSame($node, $om->getNode($path));
+        $this->assertSame($node, $om->getNodeByPath($path));
     }
 
     public function testGetNodeTypes()


### PR DESCRIPTION
this is an alternative to #151 that will move the responsibility to the transport, allowing it to optimize if it can. and cleaning up quite some code around the ObjectManager::getNode messy code.
