### PR TITLE
transport must accept null credentials

### DIFF
--- a/src/Jackalope/Transport/TransportInterface.php
+++ b/src/Jackalope/Transport/TransportInterface.php
@@ -75,7 +75,7 @@ interface TransportInterface
      *      is not recognized
      * @throws \PHPCR\RepositoryException if another error occurs
      */
-    public function login(CredentialsInterface $credentials, $workspaceName);
+    public function login(CredentialsInterface $credentials = null, $workspaceName);
 
     /***********************************************************************
      * all methods from here below require that login is called first. the *


### PR DESCRIPTION
 for doctrine-dbal it actually makes sense, jackrabbit transport can now throw a proper LoginException (but no longer a fatal error)
