### PR TITLE
Fix according to JSR-283 6.7.39

### DIFF
--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -159,7 +159,7 @@ class Row implements Iterator, RowInterface
         // for multi-values boolean/binary values we can't provide a
         // defined result so we return null
         if (is_array($value)) {
-            if (is_string($value[0])) {
+            if (is_scalar($value[0]) && !is_bool($value[0])) {
                 $value = join(' ', $value);
             } else {
                 $value = null;


### PR DESCRIPTION
This PR started from https://github.com/phpcr/phpcr-api-tests/pull/108, doctrine-dbal returned an array.
The JSR-283 specs tell us that a query should only return single-valued properties. 

We discussed that for now we will use the same as jackrabbit does: return a concatenated string for string multi-valued properties.
But that only works for string properties, and because we can't create a good way to handle boolean/binary/date multi-valued properties, I choose to return `null` for those.

Because the method is defined @api this is a BC break.
