### PR TITLE
add ability to automatically update mix:lastModified properties

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -849,7 +849,7 @@ class ObjectManager
      */
     protected function executeOperations(array $operations)
     {
-        $last = null;
+        $lastType = null;
         $batch = array();
 
         foreach ($operations as $operation) {
@@ -857,13 +857,13 @@ class ObjectManager
                 continue;
             }
 
-            if (null === $last) {
-                $last = $operation->type;
+            if (null === $lastType) {
+                $lastType = $operation->type;
             }
 
-            if ($operation->type != $last) {
-                $this->executeBatch($last, $batch);
-                $last = $operation->type;
+            if ($operation->type != $lastType) {
+                $this->executeBatch($lastType, $batch);
+                $lastType = $operation->type;
                 $batch = array();
             }
 
@@ -875,10 +875,18 @@ class ObjectManager
             return;
         }
 
-        $this->executeBatch($last, $batch);
+        $this->executeBatch($lastType, $batch);
 
     }
 
+    /**
+     * Execute a batch of operations of one type.
+     *
+     * @param int $type               type of the operations to be executed
+     * @param Operation[] $operations list of same type operations
+     *
+     * @throws \Exception
+     */
     protected function executeBatch($type, $operations)
     {
         switch ($type) {

--- a/src/Jackalope/Repository.php
+++ b/src/Jackalope/Repository.php
@@ -55,6 +55,7 @@ class Repository implements RepositoryInterface
         'transactions' => true,
         // this is JACKALOPE_OPTION_STREAM_WRAPPER
         'stream_wrapper' => true,
+        Session::OPTION_AUTO_LASTMODIFIED => true,
     );
 
     /**
@@ -105,7 +106,9 @@ class Repository implements RepositoryInterface
             throw new RepositoryException('transport failed to login without telling why');
         }
 
+        /** @var $session Session */
         $session = $this->factory->get('Session', array($this, $workspaceName, $credentials, $this->transport));
+        $session->setSessionOption(Session::OPTION_AUTO_LASTMODIFIED, $this->options[Session::OPTION_AUTO_LASTMODIFIED]);
         if ($this->options['transactions']) {
             $utx = $this->factory->get('Transaction\\UserTransaction', array($this->transport, $session, $session->getObjectManager()));
             $session->getWorkspace()->setTransactionManager($utx);

--- a/src/Jackalope/Session.php
+++ b/src/Jackalope/Session.php
@@ -48,6 +48,15 @@ class Session implements SessionInterface
     const OPTION_FETCH_DEPTH = 'jackalope.fetch_depth';
 
     /**
+     * constant for setSessionOption to manage whether nodes having
+     * mix:lastModified should automatically be updated.
+     *
+     * Disable if you want to manually control this information, e.g. in a
+     * PHPCR-ODM listener.
+     */
+    const OPTION_AUTO_LASTMODIFIED = 'jackalope.auto_lastmodified';
+
+    /**
      * A registry for all created sessions to be able to reference them by id in
      * the stream wrapper for lazy loading binary properties.
      *
@@ -753,13 +762,12 @@ class Session implements SessionInterface
     /**
      * Sets a session specific option.
      *
-     * Currently only OPTION_FETCH_DEPTH is supported.
-     *
      * @param string $key   the key to be set
      * @param mixed  $value the value to be set
      *
      * @throws InvalidArgumentException if the option is unknown
-     * @throws RepositoryException      if this option is not supported and is a behaviour relevant option
+     * @throws RepositoryException      if this option is not supported and is
+     *      a behaviour relevant option
      *
      * @see Jackalope\Transport\BaseTransport::setFetchDepth($value);
      */
@@ -769,6 +777,9 @@ class Session implements SessionInterface
         switch ($key) {
             case self::OPTION_FETCH_DEPTH:
                 $this->getTransport()->setFetchDepth($value);
+                break;
+            case self::OPTION_AUTO_LASTMODIFIED:
+                $this->getTransport()->setAutoLastModified($value);
                 break;
             default:
                 throw new InvalidArgumentException("Unknown option: $key");
@@ -789,6 +800,8 @@ class Session implements SessionInterface
         switch ($key) {
             case self::OPTION_FETCH_DEPTH:
                 return $this->getTransport()->getFetchDepth();
+            case self::OPTION_AUTO_LASTMODIFIED:
+                return $this->getTransport()->getAutoLastModified();
         }
 
         throw new InvalidArgumentException("Unknown option: $key");

--- a/src/Jackalope/Transport/BaseTransport.php
+++ b/src/Jackalope/Transport/BaseTransport.php
@@ -42,8 +42,15 @@ $/xi";
     *
     * @see TransportInterface::setFetchDepth($depth)
     */
-
     protected $fetchDepth = 0;
+
+    /**
+     * Flag to determine if mix:lastModified nodes should be updated
+     * automatically.
+     *
+     * @var boolean
+     */
+    private $autoLastModified = true;
 
     /**
      * Minimal check according to the jcr spec to see if this node name
@@ -80,6 +87,22 @@ $/xi";
     public function getFetchDepth()
     {
         return $this->fetchDepth;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAutoLastModified($autoLastModified)
+    {
+        $this->autoLastModified = $autoLastModified;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAutoLastModified()
+    {
+        return $this->autoLastModified;
     }
 
     // TODO: #46 add method to generate capabilities from implemented interfaces

--- a/src/Jackalope/Transport/RemovePropertyOperation.php
+++ b/src/Jackalope/Transport/RemovePropertyOperation.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Jackalope\Transport;
+use Jackalope\Node;
 use Jackalope\Property;
 
 /**
@@ -12,7 +13,7 @@ use Jackalope\Property;
 class RemovePropertyOperation extends Operation
 {
     /**
-     * The item to remove
+     * The property to remove.
      *
      * @var Property
      */
@@ -26,6 +27,10 @@ class RemovePropertyOperation extends Operation
      */
     public $skip = false;
 
+    /**
+     * @param string   $srcPath  Absolute path of the property to remove.
+     * @param Property $property Property object to be removed.
+     */
     public function __construct($srcPath, Property $property)
     {
         parent::__construct($srcPath, self::REMOVE_PROPERTY);

--- a/src/Jackalope/Transport/TransportInterface.php
+++ b/src/Jackalope/Transport/TransportInterface.php
@@ -348,4 +348,25 @@ interface TransportInterface
      */
     public function getFetchDepth();
 
+    /**
+     * Set whether to automatically update nodes having mix:lastModified.
+     *
+     * If this is true, the transport has to make sure that on any node change
+     * that does not already include a change to the lastModified property, the
+     * jcr:lastModified property on nodes with the mixin is set to the current
+     * DateTime, and jcr:lastModifiedBy to the user id according to the
+     * credentials.
+     *
+     * Note: On read only stores, this is never used.
+     *
+     * @param boolean $autoLastModified
+     */
+    public function setAutoLastModified($autoLastModified);
+
+    /**
+     * Get the auto last modified flag.
+     *
+     * @return boolean Whether to update the last modified information.
+     */
+    public function getAutoLastModified();
 }

--- a/tests/Jackalope/ObjectManagerTest.php
+++ b/tests/Jackalope/ObjectManagerTest.php
@@ -4,35 +4,34 @@ namespace Jackalope;
 
 class ObjectManagerTest extends TestCase
 {
-    public function testGetNodeByPath()
+    /**
+     * @var ObjectManager
+     */
+    private $om;
+
+    public function setUp()
     {
         $factory = new Factory;
+        $this->om = new ObjectManager($factory, $this->getTransportStub(), $this->getSessionMock());
+    }
+
+    public function testGetNodeByPath()
+    {
+
         $path = '/jcr:root';
-        $om = new ObjectManager($factory, $this->getTransportStub($path), $this->getSessionMock());
-        $node = $om->getNodeByPath($path);
+        $node = $this->om->getNodeByPath($path);
         $this->assertInstanceOf('Jackalope\Node', $node);
         $children = $node->getNodes();
         $this->assertInstanceOf('Iterator', $children);
         $this->assertSame(2, count($children));
-        $this->assertSame($node, $om->getNodeByPath($path));
+        $this->assertSame($node, $this->om->getNodeByPath($path));
     }
 
     public function testGetNodeTypes()
     {
-        $factory = new Factory;
-        $om = new ObjectManager($factory, $this->getTransportStub('/jcr:root'), $this->getSessionMock());
-        $nodetypes = $om->getNodeTypes();
+        $nodetypes = $this->om->getNodeTypes();
         $this->assertInstanceOf('DOMDocument', $nodetypes);
-        $nodetypes = $om->getNodeTypes(array('nt:folder', 'nt:file'));
+        $nodetypes = $this->om->getNodeTypes(array('nt:folder', 'nt:file'));
         $this->assertInstanceOf('DOMDocument', $nodetypes);
-    }
-
-}
-
-class ObjectManagerMock extends ObjectManager
-{
-    public function getObjectsByUuid()
-    {
-        return $this->objectsByUuid;
     }
 }


### PR DESCRIPTION
 fix #198

this needs adjustments in jackalope-doctrine-dbal and jackalope-jackrabbit to pass along the option, and in phpcr-bundle for the configuration option.
