### PR TITLE
Throw exception when scalar is set on mutlivalue

### DIFF
--- a/src/Jackalope/Property.php
+++ b/src/Jackalope/Property.php
@@ -707,6 +707,10 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
             throw new ValueFormatException('Can not set a single value property ('.$this->name.') with an array of values');
         }
 
+        if ($this->isMultiple && is_scalar($value)) {
+            throw new ValueFormatException('Can not set a multivalue property ('.$this->name.') with a scalar value');
+        }
+
         //TODO: check if changing type allowed.
         /*
          * if ($type !== null && ! canHaveType($type)) {


### PR DESCRIPTION
Related to: https://github.com/phpcr/phpcr-shell/issues/78

In the PHPCR-Shell it is possible to do an update on multi-value properties with a scalar (this actually works, but throws Warnings).

This is a problem in PHPCR-SHell, but also in Jackalope as this should not be allowed.
