### PR TITLE
Property getNode validation

### DIFF
--- a/src/Jackalope/Property.php
+++ b/src/Jackalope/Property.php
@@ -447,10 +447,14 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
             case PropertyType::REFERENCE:
                 $results = $this->objectManager->getNodesByIdentifier($values);
                 $results = $results->getArrayCopy();
-                if (array_keys($results) != $values) {
-                    // @codeCoverageIgnoreStart
-                    throw new RepositoryException('Internal Error: Could not find a referenced node. If the referencing node is a frozen version, this can happen, otherwise it would be a bug.');
-                    // @codeCoverageIgnoreEnd
+                $diff = array_diff(array_values($values), array_keys($results));
+
+                if (count($diff) > 0) {
+                    throw new RepositoryException(sprintf(
+                        'Internal Error: Could not find one or more referenced nodes: "%s". ' .
+                        'If the referencing node is a frozen version, this can happen, otherwise it would be a bug.',
+                        implode('", "', $diff)
+                    ));
                 }
                 break;
             case PropertyType::WEAKREFERENCE:

--- a/tests/Jackalope/PropertyTest.php
+++ b/tests/Jackalope/PropertyTest.php
@@ -2,8 +2,63 @@
 
 namespace Jackalope;
 
+use Jackalope\Factory;
+use Jackalope\TestCase;
+use PHPCR\PropertyType;
+
 class PropertyTest extends TestCase
 {
+    public function provideGetNode()
+    {
+        return array(
+            array(
+                array('1234-1234', '4321-4321'),
+                array(),
+                'Could not find one or more referenced nodes: "1234-1234", "4321-4321"',
+            ),
+            array(
+                array('1234-1234', '4321-4321'),
+                array('1234-1234'),
+                'Could not find one or more referenced nodes: "4321-4321"',
+            ),
+            array(
+                array('1234-1234', '4321-4321'),
+                array('1234-1234', '4321-4321'),
+            ),
+            array(
+                array('1234-1234', '4321-4321'),
+                array('4321-4321', '1234-1234'),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideGetNode
+     */
+    public function testGetNode($values, $nodeUuids, $exceptionMessage = null)
+    {
+        if ($exceptionMessage) {
+            $this->setExpectedException('PHPCR\RepositoryException', $exceptionMessage);
+        }
+
+        $nodes = new \ArrayObject();
+
+        foreach ($nodeUuids as $nodeUuid) {
+            $nodes[$nodeUuid] = $this->getNodeMock();
+        }
+
+        $data = array(
+            'type' => PropertyType::REFERENCE, 'value' => $values,
+        );
+        $factory = new Factory();
+        $session = $this->getSessionMock();
+        $objectManager = $this->getObjectManagerMock(array(
+            'getNodesByIdentifier' => $nodes
+        ));
+        $property = new Property($factory, $data, '/path/to', $session, $objectManager);
+        $property->getNode();
+    }
+
     public function testTypeInstances()
     {
         $this->markTestSkipped('Port this over to test property types and the helper type conversions');


### PR DESCRIPTION
- use array_diff instead of a comparison
- comparison was sometimes failing because numerical indexes were
  missing (e.g. when we remove a multi-value property during the
  session)
- we use the diff in the exception message to make it more explicit
- added test
