### PR TITLE
A node must keep its position relative to its siblings when being renamed

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -464,6 +464,10 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      */
     public function rename($newName)
     {
+        $names = (array) $this->getParent()->getNodeNames();
+        $pos = array_search($this->name, $names);
+        $next = isset($names[$pos + 1]) ? $names[$pos + 1] : null;
+
         $newPath = $this->parentPath . '/' . $newName;
 
         if (substr($newPath, 0, 2) == '//') {
@@ -471,6 +475,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
         }
 
         $this->session->move($this->path, $newPath);
+        if ($next) {
+            $this->getParent()->orderBefore($newName, $next);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #255

Test added in https://github.com/phpcr/phpcr-api-tests/pull/144
