### PR TITLE
ensure that uuid is not set on node that is not referenceable

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -524,6 +524,10 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     {
         $this->checkState();
 
+        if ($validate && 'jcr:uuid' === $name && !$this->isNodeType('mix:referenceable')) {
+            throw new ConstraintViolationException('You can only change the uuid of newly created nodes that have "referenceable" mixin.');
+        }
+
         if ($validate) {
             $types = $this->getMixinNodeTypes();
             array_push($types, $this->getPrimaryNodeType());
@@ -814,7 +818,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
             return $this->getPropertyValue('jcr:uuid');
         }
 
-        return null;
+        return $this->getPath();
     }
 
     /**


### PR DESCRIPTION
fix https://github.com/jackalope/jackalope-doctrine-dbal/issues/214

(this is also an issue with jackrabbit in some situations.)

tests are at https://github.com/phpcr/phpcr-api-tests/pull/149