### PR TITLE
use LIBXML_PARSEHUGE option to be able to import data with large binaries

### DIFF
--- a/src/Jackalope/ImportExport/ImportExport.php
+++ b/src/Jackalope/ImportExport/ImportExport.php
@@ -95,7 +95,7 @@ class ImportExport implements ImportUUIDBehaviorInterface
         }
 
         $xml = new FilteredXMLReader;
-        $xml->open($uri);
+        $xml->open($uri, null, LIBXML_PARSEHUGE);
         if (libxml_get_errors()) {
             libxml_use_internal_errors($use_errors);
             throw new InvalidSerializedDataException("Invalid xml file $uri");

--- a/src/Jackalope/ImportExport/ImportExport.php
+++ b/src/Jackalope/ImportExport/ImportExport.php
@@ -95,7 +95,11 @@ class ImportExport implements ImportUUIDBehaviorInterface
         }
 
         $xml = new FilteredXMLReader;
-        $xml->open($uri, null, LIBXML_PARSEHUGE);
+        $options = 0;
+        if (LIBXML_VERSION >= 20700) {
+            $options = LIBXML_PARSEHUGE;
+        }
+        $xml->open($uri, null, $options);
         if (libxml_get_errors()) {
             libxml_use_internal_errors($use_errors);
             throw new InvalidSerializedDataException("Invalid xml file $uri");


### PR DESCRIPTION
I had an issue with an export that could not be imported. There was a huge binary included on which the XMLReader obviously choked. Works with that extra option.