### PR TITLE
Added VersionHandler with basic checkin and checkout methods

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1559,7 +1559,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
                 if ($this->properties[$name]->isDirty()) {
                     $this->properties[$name]->setClean();
                 }
-            } elseif($validate) {
+            } elseif ($validate) {
                 $this->properties[$name]->setValue($value, $type);
             } else {
                 $this->properties[$name]->_setValue($value, $type);

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -573,7 +573,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
             return null;
         }
 
-        return $this->_setProperty($name, $value, $type, false);
+        return $this->_setProperty($name, $value, $type, false, $validate);
     }
 
     /**
@@ -1522,6 +1522,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      * @param mixed   $value
      * @param string  $type
      * @param boolean $internal whether we are setting this node through api or internally
+     * @param boolean $validate whether we are validating the change or not
      *
      * @return Property
      *
@@ -1529,7 +1530,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      * @see Node::refresh
      * @see Node::__construct
      */
-    protected function _setProperty($name, $value, $type, $internal)
+    protected function _setProperty($name, $value, $type, $internal, $validate = true)
     {
         if ($name == '' | false !== strpos($name, '/')) {
             throw new InvalidArgumentException("The name '$name' is no valid property name");
@@ -1557,8 +1558,10 @@ class Node extends Item implements IteratorAggregate, NodeInterface
                 if ($this->properties[$name]->isDirty()) {
                     $this->properties[$name]->setClean();
                 }
-            } else {
+            } elseif($validate) {
                 $this->properties[$name]->setValue($value, $type);
+            } else {
+                $this->properties[$name]->_setValue($value, $type);
             }
         }
 

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1522,7 +1522,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      * @param mixed   $value
      * @param string  $type
      * @param boolean $internal whether we are setting this node through api or internally
-     * @param boolean $validate whether we are validating the change or not
+     * @param boolean $validate whether we are validating the change or not, only internal parts of jackalope are
+     *                          allowed to set this to null
      *
      * @return Property
      *

--- a/src/Jackalope/NodeType/NodeProcessor.php
+++ b/src/Jackalope/NodeType/NodeProcessor.php
@@ -209,8 +209,7 @@ $/xi";
                                 $value = $defaultValues;
                             } elseif (isset($defaultValues[0])) {
                                 $value = $defaultValues[0];
-                            } elseif ($nodeTypeDefinition->getName() !== VersionHandler::MIX_VERSIONABLE) {
-                                // When implementing versionable or activity, we need to handle more properties explicitly
+                            } else {
                                 throw new RepositoryException(sprintf(
                                     'No default value for autocreated property "%s" at "%s"',
                                     $propertyDef->getName(),

--- a/src/Jackalope/NodeType/NodeProcessor.php
+++ b/src/Jackalope/NodeType/NodeProcessor.php
@@ -2,7 +2,6 @@
 
 namespace Jackalope\NodeType;
 
-use Doctrine\Common\Version;
 use PHPCR\NodeInterface;
 use PHPCR\NodeType\NodeDefinitionInterface;
 use PHPCR\NodeType\NodeTypeDefinitionInterface;
@@ -176,7 +175,6 @@ $/xi";
             if (!$node->hasProperty($propertyDef->getName())) {
                 if ($propertyDef->isMandatory()
                     && !$propertyDef->isAutoCreated()
-                    && $nodeTypeDefinition->getName() !== VersionHandler::MIX_VERSIONABLE
                 ) {
                     throw new RepositoryException(sprintf(
                         'Property "%s" is mandatory, but is not present while saving "%s" at "%s"',

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -5,6 +5,8 @@ use ArrayIterator;
 use InvalidArgumentException;
 
 use Jackalope\Transport\NodeTypeFilterInterface;
+use Jackalope\Version\VersionHandler;
+use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\SessionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
@@ -828,6 +830,10 @@ class ObjectManager
                         $this->transport->updateProperties($node);
                         if ($node->needsChildReordering()) {
                             $this->transport->reorderChildren($node);
+                        }
+                        // add versioning properties
+                        if ($node->isNodeType(VersionHandler::MIX_VERSIONABLE)) {
+                            VersionHandler::addVersionProperties($node, $this->transport);
                         }
                     }
                 }

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -5,8 +5,6 @@ use ArrayIterator;
 use InvalidArgumentException;
 
 use Jackalope\Transport\NodeTypeFilterInterface;
-use Jackalope\Version\GenericVersioningInterface;
-use Jackalope\Version\VersionHandler;
 use PHPCR\SessionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -5,8 +5,8 @@ use ArrayIterator;
 use InvalidArgumentException;
 
 use Jackalope\Transport\NodeTypeFilterInterface;
+use Jackalope\Version\GenericVersioningInterface;
 use Jackalope\Version\VersionHandler;
-use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\SessionInterface;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
@@ -830,10 +830,6 @@ class ObjectManager
                         $this->transport->updateProperties($node);
                         if ($node->needsChildReordering()) {
                             $this->transport->reorderChildren($node);
-                        }
-                        // add versioning properties
-                        if ($node->isNodeType(VersionHandler::MIX_VERSIONABLE)) {
-                            VersionHandler::addVersionProperties($node, $this->transport);
                         }
                     }
                 }

--- a/src/Jackalope/Repository.php
+++ b/src/Jackalope/Repository.php
@@ -2,6 +2,8 @@
 
 namespace Jackalope;
 
+use Jackalope\Version\GenericVersioningInterface;
+use Jackalope\Version\VersionHandler;
 use ReflectionClass;
 
 use Jackalope\Transport\TransportInterface;
@@ -153,6 +155,10 @@ class Repository implements RepositoryInterface
         if ($this->options['transactions']) {
             $utx = $this->factory->get('Transaction\\UserTransaction', array($this->transport, $session, $session->getObjectManager()));
             $session->getWorkspace()->setTransactionManager($utx);
+        }
+
+        if ($this->transport instanceof GenericVersioningInterface) {
+            $this->transport->setVersionHandler(new VersionHandler($session));
         }
 
         return $session;

--- a/src/Jackalope/Version/GenericVersioningInterface.php
+++ b/src/Jackalope/Version/GenericVersioningInterface.php
@@ -5,8 +5,7 @@ namespace Jackalope\Version;
 use Jackalope\Transport\VersioningInterface;
 
 /**
- * This marker interface has to be implemented by classes which want to use the generic version handler provided by
- * jackalope
+ * This interface has to be implemented by classes which want to use the generic version handler provided by jackalope
  */
 interface GenericVersioningInterface extends VersioningInterface
 {

--- a/src/Jackalope/Version/GenericVersioningInterface.php
+++ b/src/Jackalope/Version/GenericVersioningInterface.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of Sulu
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Jackalope\Version;
+
+use Jackalope\Transport\VersioningInterface;
+
+/**
+ * This marker interface has to be implemented by classes which want to use the generic version handler provided by
+ * jackalope
+ */
+interface GenericVersioningInterface extends VersioningInterface
+{
+    /**
+     * Sets the generic version handler delivered by jackalope
+     * @param VersionHandler $versionHandler
+     */
+    public function setVersionHandler(VersionHandler $versionHandler);
+}

--- a/src/Jackalope/Version/GenericVersioningInterface.php
+++ b/src/Jackalope/Version/GenericVersioningInterface.php
@@ -1,12 +1,5 @@
 <?php
-/*
- * This file is part of Sulu
- *
- * (c) MASSIVE ART WebServices GmbH
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
+
 namespace Jackalope\Version;
 
 use Jackalope\Transport\VersioningInterface;

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -2,9 +2,14 @@
 
 namespace Jackalope\Version;
 
-use Jackalope\Node;
-use Jackalope\Transport\TransportInterface;
+use Jackalope\Session;
+use Jackalope\Transport\AddNodeOperation;
+use Jackalope\Transport\WritingInterface;
+use PHPCR\InvalidItemStateException;
+use PHPCR\NodeInterface;
 use PHPCR\UnsupportedRepositoryOperationException;
+use PHPCR\Util\UUIDHelper;
+use PHPCR\Version\VersionException;
 
 class VersionHandler
 {
@@ -12,55 +17,108 @@ class VersionHandler
     const MIX_SIMPLE_VERSIONABLE = 'mix:simpleVersionable';
 
     /**
-     * @var TransportInterface
+     * @var WritingInterface
      */
-    private $transport;
+    private $objectManager;
 
-    public function __construct(TransportInterface $transport)
+    /**
+     * @var Session
+     */
+    private $session;
+
+    public function __construct(Session $session)
     {
-        $this->transport = $transport;
+        $this->objectManager = $session->getObjectManager();
+        $this->session = $session;
     }
 
-    public static function addVersionProperties(Node $node, TransportInterface $transport)
+    public function addVersionProperties(NodeInterface $node)
     {
-        // TODO solve without reflection
-        $reflection = new \ReflectionMethod(get_class($transport), 'storeNode');
-        $reflection->setAccessible(true);
+        $additionalOperations = array();
 
-        // TODO move this to the version handler
+        if ($node->hasProperty('jcr:isCheckedOut')) {
+            return $additionalOperations;
+        }
+
         $session = $node->getSession();
-        $rootNode = $session->getRootNode();
 
         $node->setProperty('jcr:isCheckedOut', true);
-
-        if (!$rootNode->hasNode('jcr:system/jcr:versionStorage')) {
-            if (!$rootNode->hasNode('jcr:system')) {
-                $rootNode->addNode('jcr:system');
-            }
-            $rootNode->addNode('jcr:system/jcr:versionStorage');
+        if (!$node->hasProperty('jcr:uuid')) {
+            $node->setProperty('jcr:uuid', UUIDHelper::generateUUID());
         }
 
-        $versionStorageNode = $rootNode->getNode('jcr:system/jcr:versionStorage');
-        if (!$versionStorageNode->hasNode($node->getIdentifier())) {
-            $versionStorageNode->addNode($node->getIdentifier(), 'nt:versionHistory');
-        }
-        $versionHistory = $versionStorageNode->getNode($node->getIdentifier());
+        $versionStorageNode = $session->getNode('/jcr:system/jcr:versionStorage');
+        $versionHistory = $versionStorageNode->addNode($node->getIdentifier(), 'nt:versionHistory');
+        $versionHistory->setProperty('jcr:uuid', UUIDHelper::generateUUID());
+        $additionalOperations[] = new AddNodeOperation($versionHistory->getPath(), $versionHistory);
         $versionHistory->setProperty('jcr:versionableUuid', $node->getIdentifier());
 
         // TODO Set jcr:copiedFrom if needed
 
-        $versionHistory->addNode('jcr:versionLabels', 'nt:versionLabels');
+        $versionLabels = $versionHistory->addNode('jcr:versionLabels', 'nt:versionLabels');
+        $additionalOperations[] = new AddNodeOperation($versionLabels->getPath(), $versionLabels);
         $rootVersion = $versionHistory->addNode('jcr:rootVersion', 'nt:version');
-        $reflection->invoke($transport, $rootVersion->getPath(), $rootVersion->getProperties());
-        $rootVersion->setClean();
+        $rootVersion->setProperty('jcr:uuid', UUIDHelper::generateUUID());
+        $additionalOperations[] = new AddNodeOperation($rootVersion->getPath(), $rootVersion);
 
         // TODO add frozen node to root version
-
-        $reflection->invoke($transport, $versionHistory->getPath(), $versionHistory->getProperties());
-        $versionHistory->setClean();
 
         $node->setProperty('jcr:versionHistory', $versionHistory);
         $node->setProperty('jcr:baseVersion', $rootVersion); // TODO set correct base version
         $node->setProperty('jcr:predecessors', array($rootVersion));
+
+        return $additionalOperations;
+    }
+
+    /**
+     * Performs a checkin for the node on the given path
+     * @param $path
+     * @return string
+     */
+    public function checkinItem($path)
+    {
+        $node = $this->objectManager->getNodeByPath($path);
+
+        if (!$node->isNodeType(static::MIX_VERSIONABLE) || !$node->isNodeType(static::MIX_SIMPLE_VERSIONABLE)) {
+            throw new UnsupportedRepositoryOperationException(
+                'Node has to implement at least "mix:versionable" to use verisoning operations'
+            );
+        }
+
+        if ($node->isModified()) {
+            throw new InvalidItemStateException(sprintf(
+                'Node "%s" contains unsaved changes',
+                $path
+            ));
+        }
+
+        if (!$node->isCheckedOut()) {
+            return $path;
+        }
+
+        if ($node->hasProperty('jcr:mergeFailed')) {
+            throw new VersionException(sprintf('Node "%s" contains unresolved merge conflicts', $path));
+        }
+
+        // TODO set subgraph to read only
+
+        $versionStorageNode = $this->objectManager->getNodeByPath('/jcr:system/jcr:versionStorage');
+
+        // FIXME add some kind of sharding
+        $versionNode = $versionStorageNode->addNode(UUIDHelper::generateUUID(), 'nt:version');
+        $versionNode->setProperty('jcr:created', new \DateTime());
+
+        // TODO create frozen node
+
+        // TODO also set the other predecessors and successors
+        $versionNode->setProperty('jcr:predecessors', $node->getProperty('jcr:predecessors')->getString());
+
+        // TODO change base version
+
+        // TODO checkin the node
+
+        $this->session->save();
+
+        return $versionNode->getPath();
     }
 }

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -7,6 +7,7 @@ use Jackalope\Transport\AddNodeOperation;
 use Jackalope\Transport\WritingInterface;
 use PHPCR\InvalidItemStateException;
 use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
 use PHPCR\UnsupportedRepositoryOperationException;
 use PHPCR\Util\UUIDHelper;
 use PHPCR\Version\VersionException;
@@ -115,7 +116,7 @@ class VersionHandler
 
         // TODO change base version
 
-        // TODO checkin the node
+        $node->setProperty('jcr:isCheckedOut', false, PropertyType::BOOLEAN, false);
 
         $this->session->save();
 

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jackalope\Version;
+
+use Jackalope\Node;
+use Jackalope\Transport\TransportInterface;
+use PHPCR\UnsupportedRepositoryOperationException;
+
+class VersionHandler
+{
+    const MIX_VERSIONABLE = 'mix:versionable';
+    const MIX_SIMPLE_VERSIONABLE = 'mix:simpleVersionable';
+
+    /**
+     * @var TransportInterface
+     */
+    private $transport;
+
+    public function __construct(TransportInterface $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    public static function addVersionProperties(Node $node, TransportInterface $transport)
+    {
+        // TODO solve without reflection
+        $reflection = new \ReflectionMethod(get_class($transport), 'storeNode');
+        $reflection->setAccessible(true);
+
+        // TODO move this to the version handler
+        $session = $node->getSession();
+        $rootNode = $session->getRootNode();
+
+        $node->setProperty('jcr:isCheckedOut', true);
+
+        if (!$rootNode->hasNode('jcr:system/jcr:versionStorage')) {
+            if (!$rootNode->hasNode('jcr:system')) {
+                $rootNode->addNode('jcr:system');
+            }
+            $rootNode->addNode('jcr:system/jcr:versionStorage');
+        }
+
+        $versionStorageNode = $rootNode->getNode('jcr:system/jcr:versionStorage');
+        if (!$versionStorageNode->hasNode($node->getIdentifier())) {
+            $versionStorageNode->addNode($node->getIdentifier(), 'nt:versionHistory');
+        }
+        $versionHistory = $versionStorageNode->getNode($node->getIdentifier());
+        $versionHistory->setProperty('jcr:versionableUuid', $node->getIdentifier());
+
+        // TODO Set jcr:copiedFrom if needed
+
+        $versionHistory->addNode('jcr:versionLabels', 'nt:versionLabels');
+        $rootVersion = $versionHistory->addNode('jcr:rootVersion', 'nt:version');
+        $reflection->invoke($transport, $rootVersion->getPath(), $rootVersion->getProperties());
+        $rootVersion->setClean();
+
+        // TODO add frozen node to root version
+
+        $reflection->invoke($transport, $versionHistory->getPath(), $versionHistory->getProperties());
+        $versionHistory->setClean();
+
+        $node->setProperty('jcr:versionHistory', $versionHistory);
+        $node->setProperty('jcr:baseVersion', $rootVersion); // TODO set correct base version
+        $node->setProperty('jcr:predecessors', array($rootVersion));
+    }
+}

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -122,6 +122,7 @@ class VersionHandler
         $versionHistoryNode = $node->getPropertyValue('jcr:versionHistory');
 
         // FIXME add some kind of sharding
+        // should avoid to have too many nodes on the same level
         $versionNode = $versionHistoryNode->addNode(UUIDHelper::generateUUID(), 'nt:version');
         $versionNode->setProperty('jcr:uuid', UUIDHelper::generateUUID());
         $versionNode->setProperty('jcr:created', new \DateTime());


### PR DESCRIPTION
This PR adds a VersionHandler, which can easily be reused among different transport layers. Currently there are very basic (and not yet complete) checkin and checkout methods.