### PR TITLE
Adding version history support

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -1809,19 +1809,18 @@ class ObjectManager
 
     /**
      * Updates a single node via the transport layer if the node is modified
+     *
      * @param NodeInterface $node The node to update
      */
-    private function updateNode($node)
+    private function updateNode(NodeInterface $node)
     {
-        /** @var $node Node */
-        if ($node->isModified()) {
-            if (!$node instanceof NodeInterface) {
-                throw new RepositoryException('Internal Error: Unknown type ' . get_class($node));
-            }
-            $this->transport->updateProperties($node);
-            if ($node->needsChildReordering()) {
-                $this->transport->reorderChildren($node);
-            }
+        if (!$node->isModified()) {
+            return;
+        }
+
+        $this->transport->updateProperties($node);
+        if ($node->needsChildReordering()) {
+            $this->transport->reorderChildren($node);
         }
     }
 }

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -115,7 +115,6 @@ class VersionHandler
             );
         }
 
-        /** @var NodeInterface $baseVersionNode */
         $baseVersionUuid = $node->getProperty('jcr:baseVersion')->getString();
         $baseVersionNode = $this->objectManager->getNodeByIdentifier($baseVersionUuid, 'Version\Version');
 
@@ -135,7 +134,6 @@ class VersionHandler
 
         // FIXME add some kind of sharding
         // should avoid to have too many nodes on the same level
-        /** @var NodeInterface $versionNode */
         $versionNode = $versionHistoryNode->addNode(UUIDHelper::generateUUID(), 'nt:version');
         $versionNode->setProperty('jcr:uuid', UUIDHelper::generateUUID());
         $versionNode->setProperty('jcr:created', new \DateTime());
@@ -223,10 +221,10 @@ class VersionHandler
     }
 
     /**
-     * Creates a frozen node
+     * Attaches a nt:frozenNode copy of $node to $versionNode
      *
-     * @param NodeInterface $versionNode
-     * @param NodeInterface $node
+     * @param NodeInterface $versionNode The version to attach the nt:frozenNode to
+     * @param NodeInterface $node The node to be copied into an nt:frozenNode
      */
     private function createFrozenNode(NodeInterface $versionNode, NodeInterface $node)
     {

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -116,7 +116,8 @@ class VersionHandler
         }
 
         /** @var NodeInterface $baseVersionNode */
-        $baseVersionNode = $node->getPropertyValue('jcr:baseVersion');
+        $baseVersionUuid = $node->getProperty('jcr:baseVersion')->getString();
+        $baseVersionNode = $this->objectManager->getNodeByIdentifier($baseVersionUuid, 'Version\Version');
 
         if (!$node->isCheckedOut()) {
             return $baseVersionNode->getPath();
@@ -129,7 +130,8 @@ class VersionHandler
         // TODO set subgraph to read only
 
         /** @var NodeInterface $versionHistoryNode */
-        $versionHistoryNode = $node->getPropertyValue('jcr:versionHistory');
+        $versionHistoryUuid = $node->getProperty('jcr:versionHistory')->getString();
+        $versionHistoryNode = $this->objectManager->getNodeByIdentifier($versionHistoryUuid, 'Version\VersionHistory');
 
         // FIXME add some kind of sharding
         // should avoid to have too many nodes on the same level

--- a/src/Jackalope/Version/VersionHandler.php
+++ b/src/Jackalope/Version/VersionHandler.php
@@ -149,9 +149,6 @@ class VersionHandler
             PropertyType::REFERENCE
         );
 
-        // FIXME Find a better way to solve the referencing not existing nodes issue
-        $this->session->save();
-
         $node->setProperty(
             'jcr:predecessors',
             array($versionNode),
@@ -173,13 +170,6 @@ class VersionHandler
             );
             $predecessorNode->setModified();
         }
-
-        $versionNode->setProperty(
-            'jcr:predecessors',
-            $node->getProperty('jcr:predecessors')->getString(),
-            PropertyType::REFERENCE,
-            false
-        );
 
         $node->setProperty('jcr:isCheckedOut', false, PropertyType::BOOLEAN, false);
         $node->setProperty('jcr:baseVersion', $versionNode, PropertyType::REFERENCE, false);


### PR DESCRIPTION
These changes will make the tests in the `VersionHistoryTest` working. It adds correct chaining of all the versions. I am skipping the tests for deleting versions, since deleting versions is also optional according to the specification.

This PR is based on the work in #285

https://github.com/jackalope/jackalope-doctrine-dbal/pull/282 is the corresponding PR for the doctrine dbal transport layer.