### PR TITLE
also mark cached child nodes as dirty during version restore

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1570,6 +1570,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * Overwrite to set the properties dirty as well.
+     *
+     * @private
      */
     public function setDirty($keepChanges = false, $targetState = false)
     {
@@ -1583,9 +1585,11 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     }
 
     /**
-     * Set all cached children as dirty.
+     * Mark all cached children as dirty.
+     *
+     * @private
      */
-    private function setChildrenDirty()
+    public function setChildrenDirty()
     {
         foreach ($this->objectManager->getCachedDescendants($this->getPath()) as $childNode) {
             $childNode->setDirty();
@@ -1597,6 +1601,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      *
      * They will be automatically deleted by the backend, but the user might
      * still have a reference to one of the property objects.
+     *
+     * @private
      */
     public function setDeleted()
     {

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -987,9 +987,11 @@ class ObjectManager
         // TODO: handle pending move operations?
 
         if (isset($this->objectsByPath['Node'][$nodePath])) {
+            $this->objectsByPath['Node'][$nodePath]->setChildrenDirty();
             $this->objectsByPath['Node'][$nodePath]->setDirty();
         }
         if (isset($this->objectsByPath['Version\\Version'][$versionPath])) {
+            $this->objectsByPath['Version\\Version'][$versionPath]->setChildrenDirty();
             $this->objectsByPath['Version\\Version'][$versionPath]->setDirty();
         }
 

--- a/tests/Jackalope/SessionTest.php
+++ b/tests/Jackalope/SessionTest.php
@@ -34,7 +34,7 @@ class SessionTest extends TestCase
         $transport = $this->getTransportStub();
         $transport->expects($this->once())
             ->method('logout');
-        $session = new Session($factory, $repository, 'x',  new SimpleCredentials('foo', 'bar'), $transport);
+        $session = new Session($factory, $repository, 'x', new SimpleCredentials('foo', 'bar'), $transport);
         $this->assertTrue($session->isLive());
         $key = $session->getRegistryKey();
         $this->assertSame($session, Session::getSessionFromRegistry($key));


### PR DESCRIPTION
this fixes the problem with jackalope-jackrabbit detected in https://github.com/phpcr/phpcr-api-tests/pull/160/files#r32370685