### PR TITLE
fix row selector name parsing

### DIFF
--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -87,15 +87,15 @@ class Row implements Iterator, RowInterface
 
         // TODO all of the normalization logic should better be moved to the Jackrabbit transport layer
         foreach ($columns as $column) {
-            $selectorName = '';
-            if (isset($column['dcr:selectorName'])) {
+            $pos = strpos($column['dcr:name'], '.');
+            if (false !== $pos) {
+                // jackalope-doctrine-dbal has the selector name both in the dcr:name and as separate column dcr:selectorName
+                $selectorName = substr($column['dcr:name'], 0, $pos);
+                $column['dcr:name'] = substr($column['dcr:name'], $pos + 1);
+            } elseif (isset($column['dcr:selectorName'])) {
                 $selectorName = $column['dcr:selectorName'];
             } else {
-                $pos = strpos($column['dcr:name'], '.');
-                if (false !== $pos) {
-                    $selectorName = substr($column['dcr:name'], 0, $pos);
-                    $column['dcr:name'] = substr($column['dcr:name'], $pos + 1);
-                }
+                $selectorName = '';
             }
 
             if ('jcr:score' === $column['dcr:name']) {


### PR DESCRIPTION
revert most of 0183cc011c36c233559a10636f5d78c6bc75b8d5 as its working around a jackalope-doctrine-dbal oddity