### PR TITLE
Jackalope\Node requires Jackalope\Factory instead of Jackalope\FactoryInterface

### DIFF
--- a/src/Jackalope/Lock/LockManager.php
+++ b/src/Jackalope/Lock/LockManager.php
@@ -35,7 +35,7 @@ class LockManager implements IteratorAggregate, LockManagerInterface
 
     /**
      * The jackalope object factory for this object
-     * @var \Jackalope\Factory
+     * @var \Jackalope\FactoryInterface
      */
     protected $factory;
 

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -22,7 +22,6 @@ use PHPCR\ItemExistsException;
 use PHPCR\Util\PathHelper;
 use PHPCR\Util\NodeHelper;
 use PHPCR\Util\UUIDHelper;
-use Jackalope\Factory;
 
 /**
  * {@inheritDoc}
@@ -110,7 +109,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      *
      * @private
      */
-    public function __construct(Factory $factory, $rawData, $path, Session $session, ObjectManager $objectManager, $new = false)
+    public function __construct(FactoryInterface $factory, $rawData, $path, Session $session, ObjectManager $objectManager, $new = false)
     {
         parent::__construct($factory, $path, $session, $objectManager, $new);
         $this->isNode = true;

--- a/src/Jackalope/Repository.php
+++ b/src/Jackalope/Repository.php
@@ -76,7 +76,7 @@ class Repository implements RepositoryInterface
     /**
      * The factory to instantiate objects
      *
-     * @var object
+     * @var FactoryInterface
      */
     protected $factory;
 


### PR DESCRIPTION
`\Jackalope\Node` forced me to extend `\Jackalope\Factory` by my custom factory instead of implementing `\Jackalope\FactoryInterface`.