### PR TITLE
Register UUID upon setProperty

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -619,6 +619,12 @@ class Node extends Item implements IteratorAggregate, NodeInterface
             return null;
         }
 
+        // if the property is the UUID, then register the UUID against the path
+        // of this node.
+        if ($name === 'jcr:uuid') {
+            $this->objectManager->registerUuid($value, $this->getPath());
+        }
+
         return $this->_setProperty($name, $value, $type, false);
     }
 

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -1872,4 +1872,25 @@ class ObjectManager
         // objectsByPath and the calling parent node can forget it
         return true;
     }
+
+    /**
+     * Register a given node path against a UUID.
+     *
+     * This is called when setting the UUID property of a node to ensure that
+     * it can be subsequently referenced by the UUID.
+     *
+     * @param string $uuid
+     * @param string $absPath
+     */
+    public function registerUuid($uuid, $absPath)
+    {
+        if (isset($this->objectsByUuid[$uuid])) {
+            throw new \RuntimeException(sprintf(
+                'Object path for UUID "%s" has already been registered to "%s"',
+                $uuid, $this->objectsByUuid[$uuid]
+            ));
+        }
+
+        $this->objectsByUuid[$uuid] = $absPath;
+    }
 }

--- a/tests/Jackalope/ObjectManagerTest.php
+++ b/tests/Jackalope/ObjectManagerTest.php
@@ -43,4 +43,22 @@ class ObjectManagerTest extends TestCase
         $nodetypes = $this->om->getNodeTypes(array('nt:folder', 'nt:file'));
         $this->assertInstanceOf('DOMDocument', $nodetypes);
     }
+
+    public function testRegisterUuid()
+    {
+        $this->om->registerUuid('1234', '/jcr:root');
+        $node = $this->om->getNodeByIdentifier('1234');
+
+        $this->assertInstanceOf('Jackalope\Node', $node);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Object path for UUID "1234" has already been registered to "/path/to/this"
+     */
+    public function testRegisterUuidAlreadyMapped()
+    {
+        $this->om->registerUuid('1234', '/path/to/this');
+        $this->om->registerUuid('1234', '/path/to/that');
+    }
 }


### PR DESCRIPTION
This PR will register the UUID with the object manager when the UUID property is set on a node.

Previous behavior:

``` php
$node->setProperty('jcr:uuid', '1234');
$session->getNodeByIdentifier('1234'); // node not found
```

New behavior:

``` php
$node->setProperty('jcr:uuid', '1234');

var_dump($session->getNodeByIdentifier('1234') === $node); // true
```
