### PR TITLE
Do not throw exception on checkState if item is deleted / set node clean after save/update.

### DIFF
--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1308,7 +1308,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
         } catch (ItemNotFoundException $ex) {
 
             // The node was deleted in another session
-            if (! $this->objectManager->purgeDisappearedNode($this->path, $keepChanges)) {
+            if (false === $this->objectManager->purgeDisappearedNode($this->path, $keepChanges)) {
                 throw new LogicException($this->path . " should be purged and not kept");
             }
             $keepChanges = false; // delete never keeps changes

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -869,6 +869,7 @@ class ObjectManager
                 if ($item->isModified() || $item->isMoved()) {
                     $item->confirmSaved();
                 }
+                $item->setClean();
             }
         }
 
@@ -1121,10 +1122,10 @@ class ObjectManager
 
         /** @var $node Node */
         foreach ($this->objectsByPath['Node'] as $node) {
-            if (! $keepChanges || ! ($node->isDeleted() || $node->isNew())) {
+            if (false === $keepChanges || ! ($node->isDeleted() || $node->isNew())) {
                 // if we keep changes, do not restore a deleted item
                 $this->objectsByUuid[$node->getIdentifier()] = $node->getPath();
-                $node->setDirty($keepChanges);
+                $node->setDirty(false);
             }
         }
     }
@@ -1812,6 +1813,7 @@ class ObjectManager
             if (false !== $uuid) {
                 unset($this->objectsByUuid[$uuid]);
             }
+
             unset($this->objectsByPath['Node'][$absPath]);
             $item->setDeleted();
         }


### PR DESCRIPTION
Set the node as clean after updating the node via. transport during the `save()` operation.

See related:
- Jackalope Doctrine DBAL: https://github.com/jackalope/jackalope-doctrine-dbal/pull/323
- PHPCR API tests: https://github.com/phpcr/phpcr-api-tests/pull/178/files
