### PR TITLE
Do not build on broken 5.3.3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.3.3
+    - php: 5.3
       env: PACKAGE_VERSION=low
 
 before_script:


### PR DESCRIPTION
As mentioned by @dbu in https://github.com/jackalope/jackalope/pull/307 do not build on 5.3.3.