### PR TITLE
cleanup

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,5 @@
 preset: psr2
 
 enabled:
-  - long_array_syntax
+  - short_array_syntax
   - duplicate_semicolon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 env:
@@ -15,7 +13,7 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env: PACKAGE_VERSION=low
 
 before_script:
@@ -24,7 +22,7 @@ before_script:
   - if [[ "$PACKAGE_VERSION" == "high" ]]; then composer update --prefer-source; fi
   - if [[ "$PACKAGE_VERSION" == "low" ]]; then composer update --prefer-lowest --prefer-source; fi
 
-script: phpunit
+script: vendor/bin/phpunit
 
 notifications:
   irc: "irc.freenode.org#jackalope"

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,16 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "jackalope/jackalope-transport": "*",
-        "php": ">=5.3.3",
+        "php": "^5.6|^7.0",
         "ext-xml": "*",
         "phpcr/phpcr-utils": "~1.2,>=1.2.6",
         "phpcr/phpcr": "~2.1.0,>=2.1.0-beta12"
     },
     "provide": {
         "phpcr/phpcr-implementation": "2.1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-0": { "Jackalope\\": "src/" }

--- a/src/Jackalope/BinaryStreamWrapper.php
+++ b/src/Jackalope/BinaryStreamWrapper.php
@@ -34,7 +34,7 @@ class BinaryStreamWrapper
      *
      * @var array
      */
-    private static $multiValueMap = array();
+    private static $multiValueMap = [];
 
     /**
      * The backend path this stream represents
@@ -45,12 +45,14 @@ class BinaryStreamWrapper
 
     /**
      * The stream once the wrapper has been accessed once.
+     *
      * @var resource
      */
     private $stream = null;
 
     /**
      * The PHPCR session to fetch data through it.
+     *
      * @var SessionInterface
      */
     private $session = null;

--- a/src/Jackalope/Factory.php
+++ b/src/Jackalope/Factory.php
@@ -16,19 +16,19 @@ class Factory implements FactoryInterface
     /**
      * @var array
      */
-    protected $classCache = array();
+    protected $classCache = [];
     
     /**
      * @var array
      */
-    protected $reflectionCache = array();
+    protected $reflectionCache = [];
 
     /**
      * {@inheritDoc}
      *
      * @throws InvalidArgumentException
      */
-    public function get($name, array $params = array())
+    public function get($name, array $params = [])
     {
         if (isset($this->classCache[$name])) {
             $name = $this->classCache[$name];

--- a/src/Jackalope/FactoryInterface.php
+++ b/src/Jackalope/FactoryInterface.php
@@ -16,8 +16,8 @@ namespace Jackalope;
  *
  * It should be used in the code like this:
  * <pre>
- * $this->factory->get('Node', array(...));
- * $this->factory->get('NodeType\PropertyDefinition', array(...));
+ * $this->factory->get('Node', [...]);
+ * $this->factory->get('NodeType\PropertyDefinition', [...]);
  * //note the \ for sub namespaces. the name is relative to the Jackalope namespace
  * </pre>
  *
@@ -42,5 +42,5 @@ interface FactoryInterface
      *
      * @return object
      */
-    public function get($name, array $params = array());
+    public function get($name, array $params = []);
 }

--- a/src/Jackalope/Item.php
+++ b/src/Jackalope/Item.php
@@ -2,7 +2,6 @@
 
 namespace Jackalope;
 
-use Jackalope\NodeType\NodeType;
 use LogicException;
 use PHPCR\NodeType\ItemDefinitionInterface;
 use PHPCR\NodeType\NodeTypeInterface;
@@ -58,8 +57,7 @@ abstract class Item implements ItemInterface
     const STATE_CLEAN = 2;
 
     /**
-     * The item has been modified locally and needs to be saved to the backend
-     * on Session::save()
+     * The item has been modified locally and needs to be saved to the backend on Session::save()
      */
     const STATE_MODIFIED = 3;
 
@@ -68,14 +66,18 @@ abstract class Item implements ItemInterface
      */
     const STATE_DELETED = 4;
 
-    /** @var int    The state of the item, one of the STATE_ constants */
+    /**
+     * @var int The state of the item, one of the STATE_ constants
+     */
     protected $state;
 
-    /** @var boolean To know whether to keep changes or not when reloading in dirty state */
+    /**
+     * @var bool To know whether to keep changes or not when reloading in dirty state
+     */
     protected $keepChanges = false;
 
     /**
-     * @var int    The state of the item saved when a transaction is started
+     * @var int The state of the item saved when a transaction is started
      *
      * @see Item::rollbackTransaction()
      */
@@ -89,13 +91,13 @@ abstract class Item implements ItemInterface
     /**
      * @var array The states an Item can take
      */
-    protected $available_states = array(
+    protected $available_states = [
         self::STATE_NEW,
         self::STATE_DIRTY,
         self::STATE_CLEAN,
         self::STATE_MODIFIED,
         self::STATE_DELETED,
-    );
+    ];
 
     /**
      * @var FactoryInterface The jackalope object factory for this object
@@ -172,7 +174,7 @@ abstract class Item implements ItemInterface
         $new = false)
     {
         $this->factory = $factory;
-        $this->valueConverter = $this->factory->get('PHPCR\Util\ValueConverter');
+        $this->valueConverter = $this->factory->get(ValueConverter::class);
         $this->session = $session;
         $this->objectManager = $objectManager;
         $this->setState($new ? self::STATE_NEW : self::STATE_CLEAN);
@@ -210,7 +212,7 @@ abstract class Item implements ItemInterface
         $this->path = $path;
         $this->depth = ('/' === $path) ? 0 : substr_count($path, '/');
         $this->name = PathHelper::getNodeName($path);
-        $this->parentPath = (0 === $this->depth) ? null : PathHelper::getParentPath($path);
+        $this->parentPath = 0 === $this->depth ? null : PathHelper::getParentPath($path);
     }
 
     /**
@@ -266,6 +268,7 @@ abstract class Item implements ItemInterface
     public function getParent()
     {
         $this->checkState();
+
         if (is_null($this->parentPath)) {
             throw new ItemNotFoundException('The root node has no parent');
         }
@@ -397,14 +400,14 @@ abstract class Item implements ItemInterface
         }
         if ($this->session->getRepository() === $otherItem->getSession()->getRepository()
             && $this->session->getWorkspace() === $otherItem->getSession()->getWorkspace()
-            && get_class($this) == get_class($otherItem)
+            && get_class($this) === get_class($otherItem)
         ) {
             if ($this instanceof Node) {
                 if ($this->uuid == $otherItem->getIdentifier()) {
                     return true;
                 }
                 // assert($this instanceof Property)
-            } elseif ($this->name == $otherItem->getName()
+            } elseif ($this->name === $otherItem->getName()
                 && $this->getParent()->isSame($otherItem->getParent())
             ) {
                 return true;
@@ -763,7 +766,7 @@ abstract class Item implements ItemInterface
      */
     public function rollbackTransaction()
     {
-        if (is_null($this->savedState)) {
+        if (null === $this->savedState) {
             $this->savedState = self::STATE_NEW;
         }
 

--- a/src/Jackalope/Lock/Lock.php
+++ b/src/Jackalope/Lock/Lock.php
@@ -22,25 +22,39 @@ class Lock implements LockInterface
      */
     protected $lockManager;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $lockOwner;
 
-    /** @var boolean */
+    /**
+     * @var boolean
+     */
     protected $isDeep;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $path;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $lockToken;
 
-    /** @var boolean */
+    /**
+     * @var boolean
+     */
     protected $isLive = true;
 
-    /** @var boolean */
+    /**
+     * @var boolean
+     */
     protected $isSessionScoped;
 
-    /** @var boolean */
+    /**
+     * @var boolean
+     */
     protected $isLockOwningSession;
 
     /**

--- a/src/Jackalope/Lock/LockInfo.php
+++ b/src/Jackalope/Lock/LockInfo.php
@@ -14,9 +14,24 @@ use PHPCR\Lock\LockInfoInterface;
  */
 class LockInfo implements LockInfoInterface
 {
+    /**
+     * @var bool
+     */
     private $isDeep = true;
+
+    /**
+     * @var bool
+     */
     private $isSessionScoped = false;
+
+    /**
+     * @var int
+     */
     private $timeoutHint = PHP_INT_MAX;
+
+    /**
+     * @var null|string
+     */
     private $ownerInfo = null;
 
     /**

--- a/src/Jackalope/Lock/LockManager.php
+++ b/src/Jackalope/Lock/LockManager.php
@@ -3,6 +3,8 @@
 namespace Jackalope\Lock;
 
 use ArrayIterator;
+use Exception;
+use InvalidArgumentException;
 use IteratorAggregate;
 use PHPCR\SessionInterface;
 use PHPCR\PathNotFoundException;
@@ -31,10 +33,11 @@ class LockManager implements IteratorAggregate, LockManagerInterface
     /**
      * @var ObjectManager
      */
-    protected $objectmanager;
+    protected $objectManager;
 
     /**
      * The jackalope object factory for this object
+     *
      * @var FactoryInterface
      */
     protected $factory;
@@ -54,7 +57,7 @@ class LockManager implements IteratorAggregate, LockManagerInterface
      *
      * @var Lock[] indexed by absPath
      */
-    protected $locks = array();
+    protected $locks = [];
 
     /**
      * Create the version manager - there should be only one per session.
@@ -67,12 +70,15 @@ class LockManager implements IteratorAggregate, LockManagerInterface
      */
     public function __construct(FactoryInterface $factory, ObjectManager $objectManager, SessionInterface $session, LockingInterface $transport)
     {
-        $this->objectmanager = $objectManager;
+        $this->objectManager = $objectManager;
         $this->factory = $factory;
         $this->session = $session;
         $this->transport = $transport;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getIterator()
     {
         return new ArrayIterator($this->getLockTokens());
@@ -122,7 +128,7 @@ class LockManager implements IteratorAggregate, LockManagerInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */
@@ -264,7 +270,7 @@ class LockManager implements IteratorAggregate, LockManagerInterface
             if ($lock->isSessionScoped() && $lock->isLockOwningSession()) {
                 try {
                     $this->unlock($path); // will tell the lock its no longer live
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     // ignore exceptions here, we don't care too much. would be nice to log though
                 }
             }

--- a/src/Jackalope/NamespaceRegistry.php
+++ b/src/Jackalope/NamespaceRegistry.php
@@ -34,19 +34,21 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
 
     /**
      * List of predefined namespaces.
+     *
      * @var array
      */
-    protected $defaultNamespaces = array(
+    protected $defaultNamespaces = [
         self::PREFIX_JCR   => self::NAMESPACE_JCR,
         self::PREFIX_SV    => self::NAMESPACE_SV,
         self::PREFIX_NT    => self::NAMESPACE_NT,
         self::PREFIX_MIX   => self::NAMESPACE_MIX,
         self::PREFIX_XML   => self::NAMESPACE_XML,
         self::PREFIX_EMPTY => self::NAMESPACE_EMPTY,
-    );
+    ];
 
     /**
      * Set of namespaces registered by the user.
+     *
      * @var array
      */
     protected $userNamespaces = null;
@@ -76,7 +78,7 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
     {
         if ($this->userNamespaces === null) {
             $namespaces = $this->transport->getNamespaces();
-            $this->userNamespaces = array();
+            $this->userNamespaces = [];
             foreach ($namespaces as $prefix => $uri) {
                 if (! array_key_exists($prefix, $this->defaultNamespaces)) {
                     $this->userNamespaces[$prefix] = $uri;
@@ -103,6 +105,7 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
         if (false !== array_search($uri, $this->defaultNamespaces)) {
             throw new NamespaceException("Can not change default namespace $prefix = $uri");
         }
+
         $this->lazyLoadNamespaces();
         //first try putting the stuff in backend, and only afterwards update local info
 
@@ -114,6 +117,7 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
             // the backend takes care of storing this, but we have to update frontend info
             unset($this->userNamespaces[$oldpref]);
         }
+
         $this->userNamespaces[$prefix] = $uri;
     }
 
@@ -239,9 +243,11 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
         if (! strncasecmp('xml', $prefix, 3)) {
             throw new NamespaceException("Do not use xml in prefixes for namespace changes: '$prefix'");
         }
+
         if (array_key_exists($prefix, $this->defaultNamespaces)) {
             throw new NamespaceException("Do not change the predefined prefixes: '$prefix'");
         }
+
         if (false !== strpos($prefix, ' ') || false !== strpos($prefix, ':')) {
             throw new NamespaceException("Not a valid namespace prefix '$prefix'");
         }

--- a/src/Jackalope/NodePathIterator.php
+++ b/src/Jackalope/NodePathIterator.php
@@ -2,19 +2,38 @@
 
 namespace Jackalope;
 
-use Jackalope\Node;
+use ArrayAccess;
+use Countable;
+use InvalidArgumentException;
+use SeekableIterator;
 
 /**
  * @license http://www.apache.org/licenses Apache License Version 2.0, January 2004
  * @license http://opensource.org/licenses/MIT MIT License
  */
-class NodePathIterator implements \SeekableIterator, \ArrayAccess, \Countable
+class NodePathIterator implements SeekableIterator, ArrayAccess, Countable
 {
+    /**
+     * @var int
+     */
     protected $position = 0;
-    protected $nodes = array();
+
+    /**
+     * @var array
+     */
+    protected $nodes = [];
+
+    /**
+     * @var array
+     */
     protected $paths;
+
     protected $typeFilter;
     protected $class;
+
+    /**
+     * @var int
+     */
     protected $count = 0;
 
     protected $batchSize;
@@ -22,8 +41,8 @@ class NodePathIterator implements \SeekableIterator, \ArrayAccess, \Countable
     public function __construct(
         ObjectManager $objectManager,
         $paths,
-        $class = 'Node',
-        $typeFilter = array(),
+        $class = Node::class,
+        $typeFilter = [],
         $batchSize = 50
     ) {
         $this->objectManager = $objectManager;
@@ -218,7 +237,7 @@ class NodePathIterator implements \SeekableIterator, \ArrayAccess, \Countable
      */
     public function offsetSet($offset, $value)
     {
-        throw new \InvalidArgumentException('Node path collection is read only.');
+        throw new InvalidArgumentException('Node path collection is read only');
     }
 
     /**
@@ -226,7 +245,7 @@ class NodePathIterator implements \SeekableIterator, \ArrayAccess, \Countable
      */
     public function offsetUnset($offset)
     {
-        throw new \InvalidArgumentException('Node path collection is read only.');
+        throw new InvalidArgumentException('Node path collection is read only');
     }
 
     /**

--- a/src/Jackalope/NodeType/ItemDefinition.php
+++ b/src/Jackalope/NodeType/ItemDefinition.php
@@ -19,6 +19,7 @@ class ItemDefinition implements ItemDefinitionInterface
 {
     /**
      * The factory to instantiate objects
+     *
      * @var FactoryInterface
      */
     protected $factory;
@@ -30,36 +31,42 @@ class ItemDefinition implements ItemDefinitionInterface
 
     /**
      * Name of the declaring node type.
+     *
      * @var string
      */
     protected $declaringNodeType;
 
     /**
      * Name of this node type.
+     *
      * @var string
      */
     protected $name;
 
     /**
      * Whether this item is autocreated.
+     *
      * @var boolean
      */
     protected $isAutoCreated;
 
     /**
      * Whether this item is mandatory.
+     *
      * @var boolean
      */
     protected $isMandatory;
 
     /**
      * Whether this item is protected.
+     *
      * @var boolean
      */
     protected $isProtected;
 
     /**
      * On parent version constant
+     *
      * @var int
      */
     protected $onParentVersion;

--- a/src/Jackalope/NodeType/NodeDefinition.php
+++ b/src/Jackalope/NodeType/NodeDefinition.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jackalope\NodeType;
 
 use PHPCR\NodeType\NodeDefinitionInterface;
@@ -21,13 +22,13 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
      * Cached list of NodeType instances populated in first call to getRequiredPrimaryTypes
      * @var array
      */
-    protected $requiredPrimaryTypes = array();
+    protected $requiredPrimaryTypes = [];
 
     /**
      * List of required primary type names as string.
      * @var array
      */
-    protected $requiredPrimaryTypeNames = array();
+    protected $requiredPrimaryTypeNames = [];
 
     /**
      * @var string
@@ -52,7 +53,7 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
         $this->allowsSameNameSiblings = $data['allowsSameNameSiblings'];
         $this->defaultPrimaryTypeName = isset($data['defaultPrimaryTypeName']) ? $data['defaultPrimaryTypeName'] : null;
         $this->requiredPrimaryTypeNames = (isset($data['requiredPrimaryTypeNames']) && count($data['requiredPrimaryTypeNames']))
-                ? $data['requiredPrimaryTypeNames'] : array(self::DEFAULT_PRIMARY_NODE);
+                ? $data['requiredPrimaryTypeNames'] : [self::DEFAULT_PRIMARY_NODE];
     }
 
     /**

--- a/src/Jackalope/NodeType/NodeProcessor.php
+++ b/src/Jackalope/NodeType/NodeProcessor.php
@@ -3,6 +3,8 @@
 namespace Jackalope\NodeType;
 
 use ArrayObject;
+use DateTime;
+use InvalidArgumentException;
 use PHPCR\ItemExistsException;
 use PHPCR\Lock\LockException;
 use PHPCR\NodeInterface;
@@ -81,11 +83,8 @@ $/xi";
      * @param ArrayObject $namespaces       List of namespaces in the current session. Keys are prefix, values are URI.
      * @param bool        $autoLastModified Whether the last modified property should be updated automatically
      */
-    public function __construct(
-        $userId,
-        ArrayObject $namespaces,
-        $autoLastModified = true
-    ) {
+    public function __construct($userId, ArrayObject $namespaces, $autoLastModified = true)
+    {
         $this->userId = (string) $userId;
         $this->autoLastModified = $autoLastModified;
         $this->namespaces = $namespaces;
@@ -106,7 +105,7 @@ $/xi";
         $nodeTypes = $node->getMixinNodeTypes();
         array_unshift($nodeTypes, $nodeDef);
 
-        $additionalOperations = array();
+        $additionalOperations = [];
         foreach ($nodeTypes as $nodeType) {
             /* @var $nodeType NodeTypeDefinitionInterface */
             $additionalOperations = array_merge(
@@ -127,7 +126,7 @@ $/xi";
      *
      * @return AddNodeOperation[] Additional operations to handle autocreated nodes.
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws RepositoryException
      * @throws ItemExistsException
      * @throws LockException
@@ -138,7 +137,7 @@ $/xi";
      */
     private function processNodeWithType(NodeInterface $node, NodeType $nodeTypeDefinition)
     {
-        $additionalOperations = array();
+        $additionalOperations = [];
 
         foreach ($nodeTypeDefinition->getDeclaredChildNodeDefinitions() as $childDef) {
             /* @var $childDef NodeDefinitionInterface */
@@ -194,7 +193,7 @@ $/xi";
                             break;
                         case 'jcr:created':
                         case 'jcr:lastModified':
-                            $value = new \DateTime();
+                            $value = new DateTime();
                             break;
                         case 'jcr:etag':
                             // TODO: http://www.day.com/specs/jcr/2.0/3_Repository_Model.html#3.7.12.1%20mix:etag
@@ -228,7 +227,7 @@ $/xi";
                     switch ($propertyDef->getName()) {
                         case 'jcr:lastModified':
                             if ($this->autoLastModified) {
-                                $prop->setValue(new \DateTime());
+                                $prop->setValue(new DateTime());
                             }
                             break;
                         case 'jcr:lastModifiedBy':
@@ -270,7 +269,7 @@ $/xi";
             case PropertyType::NAME:
                 $values = $property->getValue();
                 if (!$property->isMultiple()) {
-                    $values = array($values);
+                    $values = [$values];
                 }
                 foreach ($values as $value) {
                     $pos = strpos($value, ':');
@@ -290,7 +289,7 @@ $/xi";
             case PropertyType::PATH:
                 $values = $property->getValue();
                 if (!$property->isMultiple()) {
-                    $values = array($values);
+                    $values = [$values];
                 }
                 foreach ($values as $value) {
                     try {
@@ -304,7 +303,7 @@ $/xi";
             case PropertyType::URI:
                 $values = $property->getValue();
                 if (!$property->isMultiple()) {
-                    $values = array($values);
+                    $values = [$values];
                 }
                 foreach ($values as $value) {
                     if (!preg_match(self::VALIDATE_URI_RFC3986, $value)) {

--- a/src/Jackalope/NodeType/NodeType.php
+++ b/src/Jackalope/NodeType/NodeType.php
@@ -71,7 +71,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     public function getSupertypes()
     {
         if (null === $this->superTypes) {
-            $this->superTypes = array();
+            $this->superTypes = [];
             foreach ($this->getDeclaredSupertypes() as $superType) {
                 $this->superTypes[] = $superType;
                 $this->superTypes = array_merge($this->superTypes, $superType->getSupertypes());
@@ -89,7 +89,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     public function getSupertypeNames()
     {
         if (null === $this->superTypeNames) {
-            $this->superTypeNames = array();
+            $this->superTypeNames = [];
             foreach ($this->getSupertypes() as $superType) {
                 $this->superTypeNames[] = $superType->getName();
             }
@@ -106,7 +106,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     public function getDeclaredSupertypes()
     {
         if (null === $this->declaredSupertypes) {
-            $this->declaredSupertypes = array();
+            $this->declaredSupertypes = [];
             foreach ($this->declaredSuperTypeNames as $declaredSuperTypeName) {
                 $this->declaredSupertypes[] = $this->nodeTypeManager->getNodeType($declaredSuperTypeName);
             }
@@ -142,7 +142,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
      */
     public function isNodeType($nodeTypeName)
     {
-        return $this->getName() == $nodeTypeName || in_array($nodeTypeName, $this->getSupertypeNames());
+        return $this->getName() === $nodeTypeName || in_array($nodeTypeName, $this->getSupertypeNames());
     }
 
     /**
@@ -204,23 +204,26 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
 
         // check explicit matches first and keep wildcard definitions for later
 
-        $wildcards = array();
+        $wildcards = [];
         foreach ($propDefs as $prop) {
             if ('*' === $prop->getName()) {
                 $wildcards[] = $prop;
-            } elseif ($propertyName == $prop->getName()) {
+            } elseif ($propertyName === $prop->getName()) {
                 if (is_array($value) !== $prop->isMultiple()) {
                     if ($prop->isMultiple()) {
                         throw new ConstraintViolationException("The property definition is multivalued, but the value '$value' is not.");
                     }
+
                     if (is_array($value)) {
                         throw new ConstraintViolationException("The value $value is multivalued, but the property definition is not.");
                     }
                 }
+
                 $requiredType = $prop->getRequiredType();
                 if (PropertyType::UNDEFINED === $requiredType || $type === $requiredType) {
                     return true;
                 }
+
                 // try if we can convert. OPTIMIZE: would be nice to know without actually attempting to convert
                 try {
                     $this->valueConverter->convertType($value, $prop->getRequiredType(), $type);
@@ -239,7 +242,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
         // now check if any of the wildcards matches
         /** @var $prop PropertyDefinition */
         foreach ($wildcards as $prop) {
-            if (is_array($value) != $prop->isMultiple()) {
+            if (is_array($value) !== $prop->isMultiple()) {
                 continue;
             }
             $requiredType = $prop->getRequiredType();
@@ -310,7 +313,7 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
         foreach ($childDefs as $child) {
             if ('*' === $child->getName() || $childNodeName === $child->getName()) {
                 if ($nodeTypeName === null) {
-                    if ($child->getDefaultPrimaryTypeName() != null) {
+                    if ($child->getDefaultPrimaryTypeName() !== null) {
                         return true;
                     }
                 } else {

--- a/src/Jackalope/NodeType/NodeTypeDefinition.php
+++ b/src/Jackalope/NodeType/NodeTypeDefinition.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jackalope\NodeType;
 
 use DOMElement;
@@ -41,10 +42,12 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
      * @var string
      */
     protected $name = null;
+
     /**
      * @var boolean
      */
     protected $isAbstract = false;
+
     /**
      * Whether this is a mixin node type (otherwise it's a primary node type).
      * @var boolean
@@ -65,7 +68,7 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
      * Name of the primary item of this node type.
      * @var string
      */
-    protected $primaryItemName= null;
+    protected $primaryItemName = null;
 
     /**
      * @var array
@@ -100,7 +103,7 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     public function __construct(FactoryInterface $factory, NodeTypeManager $nodeTypeManager, $nodetype = null)
     {
         $this->factory = $factory;
-        $this->valueConverter = $this->factory->get('PHPCR\Util\ValueConverter');
+        $this->valueConverter = $this->factory->get(ValueConverter::class);
         $this->nodeTypeManager = $nodeTypeManager;
 
         if ($nodetype instanceof DOMElement) {
@@ -129,8 +132,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
         $this->hasOrderableChildNodes = $ntd->hasOrderableChildNodes();
         $this->primaryItemName = $ntd->getPrimaryItemName();
         $this->declaredSuperTypeNames = $ntd->getDeclaredSupertypeNames();
-        $this->declaredPropertyDefinitions = new ArrayObject($ntd->getDeclaredPropertyDefinitions() ?: array());
-        $this->declaredNodeDefinitions = new ArrayObject($ntd->getDeclaredChildNodeDefinitions() ?: array());
+        $this->declaredPropertyDefinitions = new ArrayObject($ntd->getDeclaredPropertyDefinitions() ?: []);
+        $this->declaredNodeDefinitions = new ArrayObject($ntd->getDeclaredChildNodeDefinitions() ?: []);
     }
 
     /**
@@ -146,19 +149,20 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
         $this->isQueryable = $data['isQueryable'];
         $this->hasOrderableChildNodes = $data['hasOrderableChildNodes'];
         $this->primaryItemName = $data['primaryItemName'] ?: null;
-        $this->declaredSuperTypeNames = (isset($data['declaredSuperTypeNames']) && count($data['declaredSuperTypeNames'])) ? $data['declaredSuperTypeNames'] : array();
+        $this->declaredSuperTypeNames = (isset($data['declaredSuperTypeNames']) && count($data['declaredSuperTypeNames'])) ? $data['declaredSuperTypeNames'] : [];
         $this->declaredPropertyDefinitions = new ArrayObject();
+
         foreach ($data['declaredPropertyDefinitions'] as $propertyDef) {
             $this->declaredPropertyDefinitions[] = $this->factory->get(
-                'NodeType\\PropertyDefinition',
-                array($propertyDef, $this->nodeTypeManager)
+                PropertyDefinition::class,
+                [$propertyDef, $this->nodeTypeManager]
             );
         }
         $this->declaredNodeDefinitions = new ArrayObject();
         foreach ($data['declaredNodeDefinitions'] as $nodeDef) {
             $this->declaredNodeDefinitions[] = $this->factory->get(
-                'NodeType\\NodeDefinition',
-                array($nodeDef, $this->nodeTypeManager)
+                NodeDefinition::class,
+                [$nodeDef, $this->nodeTypeManager]
             );
         }
     }
@@ -192,7 +196,7 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     public function getDeclaredSupertypeNames()
     {
         if (null === $this->declaredSuperTypeNames) {
-            return array(self::NAME_NT_BASE);
+            return [self::NAME_NT_BASE];
         }
 
         return $this->declaredSuperTypeNames;

--- a/src/Jackalope/NodeType/NodeTypeXmlConverter.php
+++ b/src/Jackalope/NodeType/NodeTypeXmlConverter.php
@@ -5,6 +5,7 @@ namespace Jackalope\NodeType;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+use InvalidArgumentException;
 use PHPCR\PropertyType;
 use PHPCR\RepositoryException;
 use PHPCR\Version\OnParentVersionAction;
@@ -41,7 +42,7 @@ class NodeTypeXmlConverter
      */
     public function getItemDefinitionFromXml(DOMElement $node)
     {
-        $data = array();
+        $data = [];
         $data['declaringNodeType'] = $node->getAttribute('declaringNodeType');
         $data['name'] = $node->getAttribute('name');
         $data['isAutoCreated'] = Helper::getBoolAttribute($node, 'autoCreated');
@@ -111,7 +112,7 @@ class NodeTypeXmlConverter
                 $data['requiredPrimaryTypeNames'][] = $requiredPrimaryType->nodeValue;
             }
         } else {
-            $data['requiredPrimaryTypeNames'] = array(self::DEFAULT_PRIMARY_NODE);
+            $data['requiredPrimaryTypeNames'] = [self::DEFAULT_PRIMARY_NODE];
         }
 
         return $data;
@@ -125,11 +126,11 @@ class NodeTypeXmlConverter
      * @return array
      *
      * @throws RepositoryException
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getNodeTypeDefinitionFromXml(DOMElement $node)
     {
-        $data = array();
+        $data = [];
         // nodetype
         $data['name'] = $node->getAttribute('name');
         $data['isAbstract'] = Helper::getBoolAttribute($node, 'isAbstract');
@@ -139,20 +140,20 @@ class NodeTypeXmlConverter
 
         $data['primaryItemName'] = $node->getAttribute('primaryItemName') ?: null;
 
-        $data['declaredSuperTypeNames'] = array();
+        $data['declaredSuperTypeNames'] = [];
         $xp = new DOMXPath($node->ownerDocument);
         $supertypes = $xp->query('supertypes/supertype', $node);
         foreach ($supertypes as $supertype) {
             $data['declaredSuperTypeNames'][] = $supertype->nodeValue;
         }
 
-        $data['declaredPropertyDefinitions'] = array();
+        $data['declaredPropertyDefinitions'] = [];
         $properties = $xp->query('propertyDefinition', $node);
         foreach ($properties as $propertyDefinition) {
             $data['declaredPropertyDefinitions'][] = $this->getPropertyDefinitionFromXml($propertyDefinition);
         }
 
-        $data['declaredNodeDefinitions'] = array();
+        $data['declaredNodeDefinitions'] = [];
         $declaredNodeDefinitions = $xp->query('childNodeDefinition', $node);
         foreach ($declaredNodeDefinitions as $nodeDefinition) {
             $data['declaredNodeDefinitions'][] = $this->getNodeDefinitionFromXml($nodeDefinition);
@@ -165,7 +166,7 @@ class NodeTypeXmlConverter
     {
         $xp = new DOMXpath($dom);
         $nodeTypesElements = $xp->query('/nodeTypes/nodeType');
-        $nodeTypes = array();
+        $nodeTypes = [];
         foreach ($nodeTypesElements as $nodeTypeElement) {
             $nodeTypes[] = $this->getNodeTypeDefinitionFromXml($nodeTypeElement);
         }

--- a/src/Jackalope/NodeType/PropertyDefinition.php
+++ b/src/Jackalope/NodeType/PropertyDefinition.php
@@ -26,12 +26,12 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
      * The constraint information array (array of strings)
      * @var array
      */
-    protected $valueConstraints = array();
+    protected $valueConstraints = [];
 
     /**
      * @var mixed
      */
-    protected $defaultValues = array();
+    protected $defaultValues = [];
 
     /**
      * @var boolean
@@ -40,9 +40,10 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
 
     /**
      * List of constants from \PHPCR\Query\QueryObjectModelConstantsInterface
+     *
      * @var array
      */
-    protected $availableQueryOperators = array();
+    protected $availableQueryOperators = [];
 
     /**
      * @var boolean
@@ -68,9 +69,9 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
         $this->isMultiple = isset($data['multiple']) ? $data['multiple'] : false;
         $this->isFullTextSearchable = isset($data['fullTextSearchable']) ? $data['fullTextSearchable'] : false;
         $this->isQueryOrderable = isset($data['queryOrderable']) ? $data['queryOrderable'] : false;
-        $this->valueConstraints = isset($data['valueConstraints']) ? $data['valueConstraints'] : array();
-        $this->availableQueryOperators = isset($data['availableQueryOperators']) ? $data['availableQueryOperators'] : array();
-        $this->defaultValues = isset($data['defaultValues']) ? $data['defaultValues'] : array();
+        $this->valueConstraints = isset($data['valueConstraints']) ? $data['valueConstraints'] : [];
+        $this->availableQueryOperators = isset($data['availableQueryOperators']) ? $data['availableQueryOperators'] : [];
+        $this->defaultValues = isset($data['defaultValues']) ? $data['defaultValues'] : [];
     }
 
     /**

--- a/src/Jackalope/NotImplementedException.php
+++ b/src/Jackalope/NotImplementedException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jackalope;
 
 use RuntimeException;

--- a/src/Jackalope/Observation/Event.php
+++ b/src/Jackalope/Observation/Event.php
@@ -44,7 +44,7 @@ class Event implements EventInterface
     /**
      * @var array
      */
-    protected $info = array();
+    protected $info = [];
 
     /**
      * @var string
@@ -64,7 +64,7 @@ class Event implements EventInterface
     /**
      * @var array
      */
-    protected $mixinNodeTypeNames = array();
+    protected $mixinNodeTypeNames = [];
 
     /**
      * @var NodeTypeManagerInterface
@@ -75,24 +75,24 @@ class Event implements EventInterface
      * Events that support getting the primary or mixin node types.
      * @var array
      */
-    protected static $NODE_TYPE_EVENT = array(
+    protected static $NODE_TYPE_EVENT = [
         self::NODE_ADDED,
         self::NODE_REMOVED,
         self::NODE_MOVED,
         self::PROPERTY_ADDED,
         self::PROPERTY_REMOVED,
         self::PROPERTY_CHANGED,
-    );
+    ];
 
     /**
      * Events that support getting the property type.
      * @var array
      */
-    protected static $PROPERTY_TYPE_EVENT = array(
+    protected static $PROPERTY_TYPE_EVENT = [
         self::PROPERTY_ADDED,
         self::PROPERTY_REMOVED,
         self::PROPERTY_CHANGED,
-    );
+    ];
 
     /**
      * @param FactoryInterface         $factory ignored but need by the factory
@@ -276,7 +276,7 @@ class Event implements EventInterface
     public function getMixinNodeTypes()
     {
         $this->checkNodeTypeEvent();
-        $nt = array();
+        $nt = [];
         foreach ($this->mixinNodeTypeNames as $name) {
             $nt[$name] = $this->ntm->getNodeType($name);
         }

--- a/src/Jackalope/Observation/EventFilter.php
+++ b/src/Jackalope/Observation/EventFilter.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Observation;
 
+use Jackalope\NotImplementedException;
 use PHPCR\SessionInterface;
 use PHPCR\PropertyInterface;
 use PHPCR\Observation\EventFilterInterface;
@@ -73,7 +74,7 @@ class EventFilter implements EventFilterInterface
         }
 
         if ($this->noLocal) {
-            throw new \Jackalope\NotImplementedException;
+            throw new NotImplementedException();
             if ($this->skipByNoLocal($event)) {
                 return false;
             }
@@ -277,7 +278,7 @@ class EventFilter implements EventFilterInterface
      */
     public function setNoLocal($noLocal)
     {
-        throw new \Jackalope\NotImplementedException('TODO: how can we figure out if an event was local?');
+        throw new NotImplementedException('TODO: how can we figure out if an event was local?');
         $this->noLocal = $noLocal;
 
         return $this;

--- a/src/Jackalope/Observation/ObservationManager.php
+++ b/src/Jackalope/Observation/ObservationManager.php
@@ -11,6 +11,7 @@ use PHPCR\SessionInterface;
 use Jackalope\Transport\ObservationInterface;
 use Jackalope\FactoryInterface;
 use Jackalope\NotImplementedException;
+use Traversable;
 
 /**
  * {@inheritDoc}
@@ -98,10 +99,7 @@ class ObservationManager implements IteratorAggregate, ObservationManagerInterfa
      */
     public function getEventJournal(EventFilterInterface $filter)
     {
-        return $this->factory->get(
-            'Observation\\EventJournal',
-            array($filter, $this->session, $this->transport)
-        );
+        return $this->factory->get(EventJournal::class, [$filter, $this->session, $this->transport]);
     }
 
     /**
@@ -111,13 +109,10 @@ class ObservationManager implements IteratorAggregate, ObservationManagerInterfa
      */
     public function createEventFilter()
     {
-        return $this->factory->get(
-            'Jackalope\\Observation\\EventFilter',
-            array($this->session)
-        );
+        return $this->factory->get(EventFilter::class, [$this->session]);
     }
     /**
-     * @return \Traversable The list of event listeners
+     * @return Traversable The list of event listeners
      *
      * @throws RepositoryException
      *

--- a/src/Jackalope/Property.php
+++ b/src/Jackalope/Property.php
@@ -46,7 +46,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
      * All binary stream wrapper instances
      * @var array
      */
-    protected $streams = array();
+    protected $streams = [];
 
     /**
      * The property value in suitable native format or object
@@ -55,8 +55,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     protected $value;
 
     /**
-     * length is only used for binary property, because binary loading is
-     * delayed until explicitly requested.
+     * length is only used for binary property, because binary loading is delayed until explicitly requested.
+     *
      * @var int
      */
     protected $length;
@@ -148,7 +148,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
                 $violation = true;
                 if ('jcr:mixinTypes' === $this->getDefinition()->getName()) {
                     // check that the jcr:mixinTypes are in sync with the mixin node types
-                    $mixins = array();
+                    $mixins = [];
                     foreach ($this->getParent()->getMixinNodeTypes() as $mixin) {
                         $mixins[] = $mixin->getName();
                     }
@@ -261,7 +261,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
      * {@inheritDoc}
      *
      * @throws InvalidItemStateException
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */
@@ -272,6 +272,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
         if ($this->type === PropertyType::BINARY && empty($this->value)) {
             return $this->valueConverter->convertType($this->getBinary(), PropertyType::STRING, $this->type);
         }
+
         if ($this->type !== PropertyType::STRING) {
             return $this->valueConverter->convertType($this->value, PropertyType::STRING, $this->type);
         }
@@ -294,16 +295,18 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
         if ($this->type !== PropertyType::BINARY) {
             return $this->valueConverter->convertType($this->value, PropertyType::BINARY, $this->type);
         }
+
         if (! $this->wrapBinaryStreams && null === $this->value) {
             // no caching the stream. we need to fetch the stream and then copy
             // it into a memory stream so it can be accessed more than once.
             $this->value = $this->objectManager->getBinaryStream($this->path);
         }
+
         if ($this->value !== null) {
             // we have the stream locally: no wrapping or new or updated property
             // copy the stream so the original stream stays usable for storing, fetching again...
-            $val = is_array($this->value) ? $this->value : array($this->value);
-            $ret = array();
+            $val = is_array($this->value) ? $this->value : [$this->value];
+            $ret = [];
             foreach ($val as $s) {
                 $stream = fopen('php://memory', 'rwb+');
                 $pos = ftell($s);
@@ -322,11 +325,11 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
         // return wrapped stream
         if ($this->isMultiple()) {
-            $results = array();
+            $results = [];
             // identifies all streams loaded by one backend call
             $token = md5(uniqid(mt_rand(), true));
             // start with part = 1 since 0 will not be parsed properly by parse_url
-            for ($i = 1; $i <= count($this->length); $i++) {
+            for ($i = 1, $iMax = count($this->length); $i <= $iMax; $i++) {
                 $this->streams[] = $results[] = fopen('jackalope://' . $token. '@' . $this->session->getRegistryKey() . ':' . $i . $this->path, 'rwb+');
             }
 
@@ -444,9 +447,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     {
         $this->checkState();
 
-        $values = $this->isMultiple() ? $this->value : array($this->value);
+        $values = $this->isMultiple() ? $this->value : [$this->value];
 
-        $results = array();
+        $results = [];
         switch ($this->type) {
             case PropertyType::REFERENCE:
                 $results = $this->getReferencedNodes($values, false);
@@ -488,9 +491,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     {
         $this->checkState();
 
-        $values = $this->isMultiple() ? $this->value : array($this->value);
+        $values = $this->isMultiple() ? $this->value : [$this->value];
 
-        $results = array();
+        $results = [];
         switch ($this->type) {
             case PropertyType::PATH:
             case PropertyType::STRING:
@@ -519,8 +522,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
             return $this->length;
         }
 
-        $vals = $this->isMultiple ? $this->value : array($this->value);
-        $ret = array();
+        $vals = $this->isMultiple ? $this->value : [$this->value];
+        $ret = [];
 
         foreach ($vals as $value) {
             try {
@@ -617,7 +620,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
         $value = $this->getValue();
         if (!is_array($value)) {
-            $value = array($value);
+            $value = [$value];
         }
 
         return new ArrayIterator($value);
@@ -768,9 +771,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
                 return;
             }
             if (is_array($value)) {
-                $this->length = array();
+                $this->length = [];
                 foreach ($value as $v) {
-                    $stat = is_resource($v) ? fstat($v) : array( 'size' => -1 );
+                    $stat = is_resource($v) ? fstat($v) : ['size' => -1];
                     $this->length[] = $stat['size'];
                 }
             } elseif (is_resource($value)) {
@@ -826,9 +829,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
      */
     private function getReferencedNodes($ids, $weak)
     {
-        $results = array();
+        $results = [];
         $nodes = $this->objectManager->getNodesByIdentifier($ids);
-        $missing = array();
+        $missing = [];
         foreach ($ids as $id) {
             if (isset($nodes[$id])) {
                 $results[] = $nodes[$id];

--- a/src/Jackalope/Query/NodeIterator.php
+++ b/src/Jackalope/Query/NodeIterator.php
@@ -30,8 +30,14 @@ class NodeIterator implements SeekableIterator, Countable
      */
     protected $factory;
 
+    /**
+     * @var array
+     */
     protected $rows;
 
+    /**
+     * @var int
+     */
     protected $position = 0;
 
     /**
@@ -50,8 +56,8 @@ class NodeIterator implements SeekableIterator, Countable
     {
         foreach ($this->rows as $position => $columns) {
             foreach ($columns as $column) {
-                if ($column['dcr:name'] == 'jcr:path') {
-                    if ($column['dcr:value'] == $nodeName) {
+                if ($column['dcr:name'] === 'jcr:path') {
+                    if ($column['dcr:value'] === $nodeName) {
                         $this->position = $position;
 
                         return;
@@ -90,7 +96,7 @@ class NodeIterator implements SeekableIterator, Countable
         }
 
         foreach ($this->rows[$this->position] as $column) {
-            if ($column['dcr:name'] == 'jcr:path') {
+            if ($column['dcr:name'] === 'jcr:path') {
                 $path = $column['dcr:value'];
                 break;
             }

--- a/src/Jackalope/Query/QOM/ChildNodeConstraint.php
+++ b/src/Jackalope/Query/QOM/ChildNodeConstraint.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\ChildNodeInterface;
 
 /**
@@ -30,12 +31,12 @@ class ChildNodeConstraint implements ChildNodeInterface
      * @param string $selectorName
      * @param string $parentPath   parent path the node must be child of
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $parentPath)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
         $this->parentPath = $parentPath;
         $this->selectorName = $selectorName;
@@ -70,6 +71,6 @@ class ChildNodeConstraint implements ChildNodeInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 }

--- a/src/Jackalope/Query/QOM/Column.php
+++ b/src/Jackalope/Query/QOM/Column.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\ColumnInterface;
 
 /**
@@ -36,16 +37,18 @@ class Column implements ColumnInterface
      * @param string $propertyName
      * @param string $columnName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $propertyName, $columnName = null)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         if ((null === $propertyName) != (null === $columnName)) {
-            throw new \InvalidArgumentException('Either both propertyName and columnName must be both null, or both non-null.');
+            throw new InvalidArgumentException('Either both propertyName and columnName must be both null, or both non-null.');
         }
+
         $this->selectorName = $selectorName;
         $this->propertyName = $propertyName;
         $this->columnName = $columnName;

--- a/src/Jackalope/Query/QOM/ComparisonConstraint.php
+++ b/src/Jackalope/Query/QOM/ComparisonConstraint.php
@@ -54,7 +54,7 @@ class ComparisonConstraint implements ComparisonInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 
     /**

--- a/src/Jackalope/Query/QOM/DescendantNodeConstraint.php
+++ b/src/Jackalope/Query/QOM/DescendantNodeConstraint.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\DescendantNodeInterface;
 
 /**
@@ -30,12 +31,12 @@ class DescendantNodeConstraint implements DescendantNodeInterface
      * @param string $selectorName
      * @param string $path
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $path)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
         $this->selectorName = $selectorName;
         $this->path = $path;
@@ -70,6 +71,6 @@ class DescendantNodeConstraint implements DescendantNodeInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 }

--- a/src/Jackalope/Query/QOM/FullTextSearchConstraint.php
+++ b/src/Jackalope/Query/QOM/FullTextSearchConstraint.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\FullTextSearchInterface;
 use PHPCR\Query\QOM\StaticOperandInterface;
 
@@ -36,13 +37,14 @@ class FullTextSearchConstraint implements FullTextSearchInterface
      * @param string $selectorName
      * @param string $propertyName
      * @param string $fullTextSearchExpression
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $propertyName, $fullTextSearchExpression)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         $this->propertyName = $propertyName;
         $this->searchExpression = $fullTextSearchExpression;
         $this->selectorName = $selectorName;
@@ -87,6 +89,6 @@ class FullTextSearchConstraint implements FullTextSearchInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 }

--- a/src/Jackalope/Query/QOM/FullTextSearchScore.php
+++ b/src/Jackalope/Query/QOM/FullTextSearchScore.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\FullTextSearchScoreInterface;
 
 /**
@@ -24,13 +25,14 @@ class FullTextSearchScore implements FullTextSearchScoreInterface
      *
      * @param string $selectorName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         $this->selectorName = $selectorName;
     }
 

--- a/src/Jackalope/Query/QOM/NodeLocalName.php
+++ b/src/Jackalope/Query/QOM/NodeLocalName.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\NodeLocalNameInterface;
 
 /**
@@ -24,13 +25,14 @@ class NodeLocalName implements NodeLocalNameInterface
      *
      * @param string $selectorName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         $this->selectorName = $selectorName;
     }
 

--- a/src/Jackalope/Query/QOM/NodeName.php
+++ b/src/Jackalope/Query/QOM/NodeName.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\NodeNameInterface;
 
 /**
@@ -24,13 +25,14 @@ class NodeName implements NodeNameInterface
      *
      * @param string $selectorName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         $this->selectorName = $selectorName;
     }
 

--- a/src/Jackalope/Query/QOM/PropertyExistence.php
+++ b/src/Jackalope/Query/QOM/PropertyExistence.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\PropertyExistenceInterface;
 
 /**
@@ -30,12 +31,12 @@ class PropertyExistence implements PropertyExistenceInterface
      * @param string $selectorName
      * @param string $propertyName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $propertyName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
         $this->selectorName = $selectorName;
         $this->propertyName = $propertyName;
@@ -70,6 +71,6 @@ class PropertyExistence implements PropertyExistenceInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 }

--- a/src/Jackalope/Query/QOM/PropertyValue.php
+++ b/src/Jackalope/Query/QOM/PropertyValue.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\PropertyValueInterface;
 
 /**
@@ -30,13 +31,14 @@ class PropertyValue implements PropertyValueInterface
      * @param string $selectorName
      * @param string $propertyName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $propertyName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
+
         $this->selectorName = $selectorName;
         $this->propertyName = $propertyName;
     }

--- a/src/Jackalope/Query/QOM/QueryObjectModel.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModel.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\QueryObjectModelInterface;
 use PHPCR\Query\QOM\SourceInterface;
 use PHPCR\Query\QOM\ConstraintInterface;
@@ -13,6 +14,7 @@ use Jackalope\ObjectManager;
 use Jackalope\Query\SqlQuery;
 use Jackalope\FactoryInterface;
 use Jackalope\NotImplementedException;
+use PHPCR\Util\ValueConverter;
 
 /**
  * {@inheritDoc}
@@ -57,7 +59,7 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
      * @param array $orderings
      * @param array $columns
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct(
         FactoryInterface $factory,
@@ -68,14 +70,16 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
     {
         foreach ($orderings as $o) {
             if (! $o instanceof OrderingInterface) {
-                throw new \InvalidArgumentException('Not a valid ordering: '.$o);
+                throw new InvalidArgumentException("Not a valid ordering: $o");
             }
         }
+
         foreach ($columns as $c) {
             if (! $c instanceof ColumnInterface) {
-                throw new \InvalidArgumentException('Not a valid column: '.$c);
+                throw new InvalidArgumentException("Not a valid column: $c");
             }
         }
+
         parent::__construct($factory, '', $objectManager);
         $this->source = $source;
         $this->constraint = $constraint;
@@ -141,7 +145,7 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
      */
     public function getStatement()
     {
-        $valueConverter = $this->factory->get('PHPCR\Util\ValueConverter');
+        $valueConverter = $this->factory->get(ValueConverter::class);
         $converter = new QomToSql2QueryConverter(new Sql2Generator($valueConverter));
 
         return $converter->convert($this);

--- a/src/Jackalope/Query/QOM/QueryObjectModelFactory.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModelFactory.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use Jackalope\ObjectManager;
 use Jackalope\FactoryInterface;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface;
@@ -25,6 +26,7 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 {
     /**
      * The factory to instantiate objects
+     *
      * @var FactoryInterface
      */
     protected $factory;
@@ -56,12 +58,12 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     public function createQuery(
         SourceInterface $source,
         ConstraintInterface $constraint = null,
-        array $orderings = array(),
-        array $columns = array())
+        array $orderings = [],
+        array $columns = [])
     {
         return $this->factory->get(
-            'Query\QOM\QueryObjectModel',
-            array($this->objectManager, $source, $constraint, $orderings, $columns)
+            QueryObjectModel::class,
+            [$this->objectManager, $source, $constraint, $orderings, $columns]
         );
     }
 
@@ -181,7 +183,7 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */
@@ -223,7 +225,7 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */
@@ -245,7 +247,7 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */
@@ -267,7 +269,7 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/QueryObjectModelSql1.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModelSql1.php
@@ -14,6 +14,7 @@ use Jackalope\ObjectManager;
 use Jackalope\Query\Sql1Query;
 use Jackalope\FactoryInterface;
 use Jackalope\NotImplementedException;
+use PHPCR\Util\ValueConverter;
 
 /**
  * {@inheritDoc}
@@ -58,7 +59,7 @@ class QueryObjectModelSql1 extends Sql1Query implements QueryObjectModelInterfac
      * @param array $orderings
      * @param array $columns
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct(
         FactoryInterface $factory,
@@ -142,7 +143,7 @@ class QueryObjectModelSql1 extends Sql1Query implements QueryObjectModelInterfac
      */
     public function getStatement()
     {
-        $valueConverter = $this->factory->get('PHPCR\Util\ValueConverter');
+        $valueConverter = $this->factory->get(ValueConverter::class);
         $converter = new QomToSql1QueryConverter(new Sql1Generator($valueConverter));
 
         return $converter->convert($this);

--- a/src/Jackalope/Query/QOM/SameNode.php
+++ b/src/Jackalope/Query/QOM/SameNode.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\SameNodeInterface;
 
 /**
@@ -30,12 +31,12 @@ class SameNode implements SameNodeInterface
      * @param string $selectorName
      * @param string $path
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $path)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
         $this->selectorName = $selectorName;
         $this->path = $path;
@@ -70,6 +71,6 @@ class SameNode implements SameNodeInterface
      */
     public function getConstraints()
     {
-        return array($this);
+        return [$this];
     }
 }

--- a/src/Jackalope/Query/QOM/Selector.php
+++ b/src/Jackalope/Query/QOM/Selector.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query\QOM;
 
+use InvalidArgumentException;
 use PHPCR\Query\QOM\SelectorInterface;
 
 /**
@@ -30,12 +31,12 @@ class Selector implements SelectorInterface
      * @param string $nodeTypeName
      * @param string $selectorName
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($selectorName, $nodeTypeName)
     {
         if (null === $selectorName) {
-            throw new \InvalidArgumentException('Required argument selectorName may not be null.');
+            throw new InvalidArgumentException('Required argument selectorName may not be null.');
         }
         $this->selectorName = $selectorName;
         $this->nodeTypeName = $nodeTypeName;

--- a/src/Jackalope/Query/Query.php
+++ b/src/Jackalope/Query/Query.php
@@ -24,24 +24,28 @@ abstract class Query implements QueryInterface
 {
     /**
      * The factory to instantiate objects
+     *
      * @var FactoryInterface
      */
     protected $factory;
 
     /**
      * The query statement
+     *
      * @var string
      */
     protected $statement;
 
     /**
      * Limit for the query
+     *
      * @var integer
      */
     protected $limit;
 
     /**
      * Offset to start results from
+     *
      * @var integer
      */
     protected $offset;
@@ -52,8 +56,10 @@ abstract class Query implements QueryInterface
      * @var ObjectManager
      */
     protected $objectManager;
+
     /**
      * If this is a stored query, the path to the node that stores this query.
+     *
      * @var string
      */
     protected $path;
@@ -99,13 +105,7 @@ abstract class Query implements QueryInterface
         }
         $transport = $this->objectManager->getTransport();
         $rawData = $transport->query($this);
-        $queryResult = $this->factory->get(
-            'Query\QueryResult',
-            array(
-                $rawData,
-                $this->objectManager,
-            )
-        );
+        $queryResult = $this->factory->get(QueryResult::class, [$rawData, $this->objectManager]);
 
         return $queryResult;
     }

--- a/src/Jackalope/Query/QueryManager.php
+++ b/src/Jackalope/Query/QueryManager.php
@@ -1,6 +1,7 @@
 <?php
 namespace Jackalope\Query;
 
+use Jackalope\Query\QOM\QueryObjectModelFactory;
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryManagerInterface;
 use PHPCR\Query\InvalidQueryException;
@@ -20,6 +21,7 @@ class QueryManager implements QueryManagerInterface
 {
     /**
      * The factory to instantiate objects
+     *
      * @var FactoryInterface
      */
     protected $factory;
@@ -51,13 +53,14 @@ class QueryManager implements QueryManagerInterface
         if (!in_array($language, $this->getSupportedQueryLanguages())) {
             throw new InvalidQueryException("Unsupported query language: $language");
         }
+
         switch ($language) {
             case QueryInterface::JCR_SQL2:
-                return $this->factory->get('Query\SqlQuery', array($statement, $this->objectManager));
+                return $this->factory->get(SqlQuery::class, [$statement, $this->objectManager]);
             case QueryInterface::XPATH:
-                return $this->factory->get('Query\XpathQuery', array($statement, $this->objectManager));
+                return $this->factory->get(XpathQuery::class, [$statement, $this->objectManager]);
             case QueryInterface::SQL:
-                return $this->factory->get('Query\Sql1Query', array($statement, $this->objectManager));
+                return $this->factory->get(Sql1Query::class, [$statement, $this->objectManager]);
             case QueryInterface::JCR_JQOM:
                 throw new InvalidQueryException('Please use getQOMFactory to get the query object model factory. You can not build a QOM query from a string.');
             default:
@@ -72,7 +75,7 @@ class QueryManager implements QueryManagerInterface
      */
     public function getQOMFactory()
     {
-        return $this->factory->get('Query\QOM\QueryObjectModelFactory', array($this->objectManager));
+        return $this->factory->get(QueryObjectModelFactory::class, [$this->objectManager]);
     }
 
     /**

--- a/src/Jackalope/Query/QueryResult.php
+++ b/src/Jackalope/Query/QueryResult.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Query;
 
+use Iterator;
 use Jackalope\ObjectManager;
 use Jackalope\FactoryInterface;
 use PHPCR\Query\QueryResultInterface;
@@ -33,7 +34,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      * @see QueryInterface::query()
      * @var array
      */
-    protected $rows = array();
+    protected $rows = [];
 
     /**
      * Create a new query result from raw data from transport.
@@ -55,7 +56,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      * Implement the IteratorAggregate interface and returns exactly the same
      * iterator as QueryResult::getRows()
      *
-     * @return \Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     * @return Iterator implementing <b>SeekableIterator</b> and <b>Countable</b>.
      *      Keys are the row position in this result set, Values are the
      *      RowInterface instances.
      *
@@ -77,7 +78,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      */
     public function getColumnNames()
     {
-        $columnNames = array();
+        $columnNames = [];
 
         foreach ($this->rows as $row) {
             foreach ($row as $columns) {
@@ -100,7 +101,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      */
     public function getRows()
     {
-        return $this->factory->get('Query\RowIterator', array($this->objectmanager, $this->rows));
+        return $this->factory->get(RowIterator::class, [$this->objectmanager, $this->rows]);
     }
 
     /**
@@ -111,10 +112,11 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
     public function getNodes($prefetch = false)
     {
         if ($prefetch !== true) {
-            return $this->factory->get('Query\NodeIterator', array($this->objectmanager, $this->rows));
+            return $this->factory->get(NodeIterator::class, [$this->objectmanager, $this->rows]);
         }
 
-        $paths = array();
+        $paths = [];
+
         foreach ($this->getRows() as $row) {
             $paths[] = $row->getPath();
         }
@@ -129,7 +131,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      */
     public function getSelectorNames()
     {
-        $selectorNames = array();
+        $selectorNames = [];
 
         foreach ($this->rows as $row) {
             foreach ($row as $column) {

--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -36,9 +36,10 @@ class Row implements Iterator, RowInterface
     /**
      * Columns of this result row: array of array with fields dcr:name and
      * dcr:value
+     *
      * @var array
      */
-    protected $columns = array();
+    protected $columns = [];
 
     /**
      * Which column we are on when iterating over the columns
@@ -51,21 +52,23 @@ class Row implements Iterator, RowInterface
      *
      * @var array of float
      */
-    protected $score = array();
+    protected $score = [];
 
     /**
      * The path to the node for each selector
      *
      * @var array of string
      */
-    protected $path = array();
+    protected $path = [];
 
     /**
      * Cached list of values extracted from columns to avoid double work.
+     *
      * @var array
+     *
      * @see Row::getValues()
      */
-    protected $values = array();
+    protected $values = [];
 
     /**
      * The default selector name
@@ -130,7 +133,7 @@ class Row implements Iterator, RowInterface
      */
     public function getValues()
     {
-        $values = array();
+        $values = [];
         foreach ($this->values as $selectorName => $columns) {
             foreach ($columns as $key => $value) {
                 $values[$selectorName.'.'.$key] = $value;

--- a/src/Jackalope/Query/RowIterator.php
+++ b/src/Jackalope/Query/RowIterator.php
@@ -53,7 +53,7 @@ class RowIterator implements SeekableIterator, Countable
     /**
      * @param int $position
      *
-     * @throws \OutOfBoundsException
+     * @throws OutOfBoundsException
      */
     public function seek($position)
     {
@@ -83,7 +83,7 @@ class RowIterator implements SeekableIterator, Countable
             return null;
         }
 
-        return $this->factory->get('Query\Row', array($this->objectManager, $this->rows[$this->position]));
+        return $this->factory->get(Row::class, [$this->objectManager, $this->rows[$this->position]]);
     }
 
     public function key()

--- a/src/Jackalope/Transaction/UserTransaction.php
+++ b/src/Jackalope/Transaction/UserTransaction.php
@@ -23,12 +23,14 @@ class UserTransaction implements UserTransactionInterface
 {
     /**
      * The factory to instantiate objects
+     *
      * @var FactoryInterface
      */
     protected $factory;
 
     /**
-     * Instance of an implementation of the \PHPCR\SessionInterface.
+     * Instance of an implementation of the PHPCR\SessionInterface.
+     *
      * @var SessionInterface
      */
     protected $session;
@@ -40,13 +42,14 @@ class UserTransaction implements UserTransactionInterface
 
     /**
      * Instance of an implementation of the TransactionInterface transport
+     *
      * @var TransactionInterface
      */
     protected $transport;
 
     /**
-     * Stores the current state of the application, whether it is inside a
-     * transaction or not
+     * Stores the current state of the application, whether it is inside a transaction or not
+     *
      * @var bool
      */
     protected $inTransaction = false;

--- a/src/Jackalope/Transport/AbstractReadLoggingWrapper.php
+++ b/src/Jackalope/Transport/AbstractReadLoggingWrapper.php
@@ -85,7 +85,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
      */
     public function getNode($path)
     {
-        $this->logger->startCall(__FUNCTION__, func_get_args(), array('fetchDepth' => $this->transport->getFetchDepth()));
+        $this->logger->startCall(__FUNCTION__, func_get_args(), ['fetchDepth' => $this->transport->getFetchDepth()]);
         $result = $this->transport->getNode($path);
         $this->logger->stopCall();
         return $result;
@@ -96,7 +96,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
      */
     public function getNodes($paths)
     {
-        $this->logger->startCall(__FUNCTION__, func_get_args(), array('fetchDepth' => $this->transport->getFetchDepth()));
+        $this->logger->startCall(__FUNCTION__, func_get_args(), ['fetchDepth' => $this->transport->getFetchDepth()]);
         $result = $this->transport->getNodes($paths);
         $this->logger->stopCall();
         return $result;
@@ -107,7 +107,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
      */
     public function getNodesByIdentifier($identifiers)
     {
-        $this->logger->startCall(__FUNCTION__, func_get_args(), array('fetchDepth' => $this->transport->getFetchDepth()));
+        $this->logger->startCall(__FUNCTION__, func_get_args(), ['fetchDepth' => $this->transport->getFetchDepth()]);
         $result = $this->transport->getNodesByIdentifier($identifiers);
         $this->logger->stopCall();
         return $result;
@@ -118,7 +118,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
      */
     public function getProperty($path)
     {
-        $this->logger->startCall(__FUNCTION__, func_get_args(), array('fetchDepth' => $this->transport->getFetchDepth()));
+        $this->logger->startCall(__FUNCTION__, func_get_args(), ['fetchDepth' => $this->transport->getFetchDepth()]);
         $result = $this->transport->getProperty($path);
         $this->logger->stopCall();
         return $result;
@@ -129,7 +129,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
      */
     public function getNodeByIdentifier($uuid)
     {
-        $this->logger->startCall(__FUNCTION__, func_get_args(), array('fetchDepth' => $this->transport->getFetchDepth()));
+        $this->logger->startCall(__FUNCTION__, func_get_args(), ['fetchDepth' => $this->transport->getFetchDepth()]);
         $result = $this->transport->getNodeByIdentifier($uuid);
         $this->logger->stopCall();
         return $result;
@@ -190,7 +190,7 @@ abstract class AbstractReadLoggingWrapper implements TransportInterface
     /**
      * {@inheritDoc}
      */
-    public function getNodeTypes($nodeTypes = array())
+    public function getNodeTypes($nodeTypes = [])
     {
         $this->logger->startCall(__FUNCTION__, func_get_args());
         $result = $this->transport->getNodeTypes($nodeTypes);

--- a/src/Jackalope/Transport/Logging/DebugStack.php
+++ b/src/Jackalope/Transport/Logging/DebugStack.php
@@ -18,7 +18,7 @@ class DebugStack implements LoggerInterface
      *
      * @var array
      */
-    public $calls = array();
+    public $calls = [];
 
     /**
      * If the logger is enabled (log calls) or not.
@@ -51,7 +51,7 @@ class DebugStack implements LoggerInterface
     {
         if ($this->enabled) {
             $this->start = microtime(true);
-            $call = array('method' => $method, 'params' => $params, 'env' => $env, 'executionMS' => 0);
+            $call = ['method' => $method, 'params' => $params, 'env' => $env, 'executionMS' => 0];
 
             if (true === $this->backtrace) {
                 $call['caller'] = $this->getBacktrace();
@@ -85,18 +85,21 @@ class DebugStack implements LoggerInterface
     {
         $fullBacktrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-        $backtrace = array();
+        $backtrace = [];
         foreach ($fullBacktrace as $trace) {
             $string = '';
             if (isset($trace['class'])) {
                 $string .= $trace['class'];
             }
+
             if (isset($trace['function'])) {
                 $string .= '->' . $trace['function'];
             }
+
             if (isset($trace['line'])) {
                 $string .= '#' . $trace['line'];
             }
+
             $backtrace[] = $string;
         }
 

--- a/src/Jackalope/Transport/Logging/LoggerChain.php
+++ b/src/Jackalope/Transport/Logging/LoggerChain.php
@@ -13,7 +13,7 @@ class LoggerChain implements LoggerInterface
     /**
      * @var LoggerInterface[]
      */
-    private $loggers = array();
+    private $loggers = [];
 
     /**
      * Adds a logger in the chain.

--- a/src/Jackalope/Transport/Logging/Psr3Logger.php
+++ b/src/Jackalope/Transport/Logging/Psr3Logger.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface as Psr3LoggerInterface;
 class Psr3Logger implements LoggerInterface
 {
     const MAX_STRING_LENGTH = 32;
+
     const BINARY_DATA_VALUE = '(binary value)';
 
     /**
@@ -69,7 +70,7 @@ class Psr3Logger implements LoggerInterface
                 }
             }
 
-            $this->logger->info($method, array('params' => $params, 'env' => $env));
+            $this->logger->info($method, ['params' => $params, 'env' => $env]);
         }
     }
 

--- a/src/Jackalope/Transport/NodeTypeCndManagementInterface.php
+++ b/src/Jackalope/Transport/NodeTypeCndManagementInterface.php
@@ -22,8 +22,7 @@ use Jackalope\NodeType\NodeTypeManager;
 interface NodeTypeCndManagementInterface extends TransportInterface
 {
     /**
-     * Register namespaces and new node types or update node types based on a
-     * jackrabbit cnd string
+     * Register namespaces and new node types or update node types based on a jackrabbit CND string
      *
      * @param string  $cnd         The cnd definition as string
      * @param boolean $allowUpdate whether to fail if node already exists or to update it

--- a/src/Jackalope/Transport/Operation.php
+++ b/src/Jackalope/Transport/Operation.php
@@ -11,8 +11,11 @@ namespace Jackalope\Transport;
 abstract class Operation
 {
     const ADD_NODE = 'add-node';
+
     const MOVE_NODE = 'move-node';
+
     const REMOVE_NODE = 'remove-node';
+
     const REMOVE_PROPERTY = 'remove-property';
 
     /**

--- a/src/Jackalope/Transport/QueryInterface.php
+++ b/src/Jackalope/Transport/QueryInterface.php
@@ -23,19 +23,20 @@ interface QueryInterface extends TransportInterface
      * Implementors: Expose all information required by the transport layers to
      * execute the query with getters.
      *
-     * array(
+     * [
      *     //row 1
-     *     array(
+     *     [
      *         //column1
-     *         array('dcr:name' => 'value1',
-     *               'dcr:value' => 'value2',
-     *               'dcr:selectorName' => 'value3' //optional
-     *         ),
+     *         [
+     *              'dcr:name' => 'value1',
+     *              'dcr:value' => 'value2',
+     *              'dcr:selectorName' => 'value3' // optional
+     *         ],
      *         //column 2...
-     *     ),
+     *     ],
      *     //row 2
-     *     array(...
-     * )
+     *     [...]
+     * ]
      *
      * @param Query $query the query object
      *

--- a/src/Jackalope/Transport/RemovePropertyOperation.php
+++ b/src/Jackalope/Transport/RemovePropertyOperation.php
@@ -20,14 +20,6 @@ class RemovePropertyOperation extends Operation
     public $property;
 
     /**
-     * Whether this remove operations was later determined to be skipped
-     * (i.e. a parent node is removed as well.)
-     *
-     * @var bool
-     */
-    public $skip = false;
-
-    /**
      * @param string   $srcPath  Absolute path of the property to remove.
      * @param Property $property Property object to be removed.
      */

--- a/src/Jackalope/Transport/StandardNodeTypes.php
+++ b/src/Jackalope/Transport/StandardNodeTypes.php
@@ -2,6 +2,10 @@
 
 namespace Jackalope\Transport;
 
+use PHPCR\PropertyType;
+use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as QOMConstantsInterface;
+use PHPCR\Version\OnParentVersionAction;
+
 /**
  * Utility class for transports that do not use jackrabbit to provide the
  * standard node type information.
@@ -26,3822 +30,3262 @@ class StandardNodeTypes
      */
     public static function getNodeTypeData()
     {
-        return array(
-            'mix:created' =>
-            array(
+        return [
+            'mix:created' => [
                 'name' => 'mix:created',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:created',
                         'name' => 'jcr:createdBy',
                         'isAutoCreated' => true,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:created',
                         'name' => 'jcr:created',
                         'isAutoCreated' => true,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 5,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::DATE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:etag' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:etag' => [
                 'name' => 'mix:etag',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:etag',
                         'name' => 'jcr:etag',
                         'isAutoCreated' => true,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:language' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:language' => [
                 'name' => 'mix:language',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:language',
                         'name' => 'jcr:language',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:lastModified' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:lastModified' => [
                 'name' => 'mix:lastModified',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:lastModified',
                         'name' => 'jcr:lastModifiedBy',
                         'isAutoCreated' => true,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:lastModified',
                         'name' => 'jcr:lastModified',
                         'isAutoCreated' => true,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 5,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::DATE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:lifecycle' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:lifecycle' => [
                 'name' => 'mix:lifecycle',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:lifecycle',
                         'name' => 'jcr:lifecyclePolicy',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 3,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::INITIALIZE,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:lifecycle',
                         'name' => 'jcr:currentLifecycleState',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 3,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::INITIALIZE,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:lockable' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:lockable' => [
                 'name' => 'mix:lockable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:lockable',
                         'name' => 'jcr:lockIsDeep',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:lockable',
                         'name' => 'jcr:lockOwner',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:mimeType' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:mimeType' => [
                 'name' => 'mix:mimeType',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:mimeType',
                         'name' => 'jcr:encoding',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:mimeType',
                         'name' => 'jcr:mimeType',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:referenceable' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:referenceable' => [
                 'name' => 'mix:referenceable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:referenceable',
                         'name' => 'jcr:uuid',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 3,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::INITIALIZE,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:shareable' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ]
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:shareable' => [
                 'name' => 'mix:shareable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:simpleVersionable' =>
-            array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:simpleVersionable' => [
                 'name' => 'mix:simpleVersionable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:simpleVersionable',
                         'name' => 'jcr:isCheckedOut',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                        'defaultValues' =>
-                        array(
-                            0 => 'true',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:title' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                        'defaultValues' => [
+                            'true',
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:title' => [
                 'name' => 'mix:title',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:title',
                         'name' => 'jcr:description',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:title',
                         'name' => 'jcr:title',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'mix:versionable' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'mix:versionable' => [
                 'name' => 'mix:versionable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'mix:simpleVersionable',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'mix:simpleVersionable',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:predecessors',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:mergeFailed',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:activity',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:activity',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:activity',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:configuration',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:configuration',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:configuration',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:versionHistory',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:versionHistory',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    5 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:versionHistory',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'mix:versionable',
                         'name' => 'jcr:baseVersion',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:activity' =>
-            array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:activity' => [
                 'name' => 'nt:activity',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:activity',
                         'name' => 'jcr:activityTitle',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:address' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:address' => [
                 'name' => 'nt:address',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:workspace',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:path',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 8,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::PATH,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:host',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:port',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:protocol',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    5 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:repository',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    6 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:address',
                         'name' => 'jcr:id',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 10,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::WEAKREFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:base' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:base' => [
                 'name' => 'nt:base',
                 'isAbstract' => true,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:base',
                         'name' => 'jcr:mixinTypes',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 4,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COMPUTE,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:base',
                         'name' => 'jcr:primaryType',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 4,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COMPUTE,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:childNodeDefinition' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:childNodeDefinition' => [
                 'name' => 'nt:childNodeDefinition',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:requiredPrimaryTypes',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                        'defaultValues' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                        'defaultValues' => [
+                            'nt:base',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:autoCreated',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:defaultPrimaryType',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:protected',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:name',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    5 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:mandatory',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    6 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:sameNameSiblings',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    7 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:childNodeDefinition',
                         'name' => 'jcr:onParentVersion',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'COPY',
-                            1 => 'VERSION',
-                            2 => 'INITIALIZE',
-                            3 => 'COMPUTE',
-                            4 => 'IGNORE',
-                            5 => 'ABORT',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:configuration' =>
-            array(
+                        'valueConstraints' => [
+                            OnParentVersionAction::ACTIONNAME_COPY,
+                            OnParentVersionAction::ACTIONNAME_VERSION,
+                            OnParentVersionAction::ACTIONNAME_INITIALIZE,
+                            OnParentVersionAction::ACTIONNAME_COMPUTE,
+                            OnParentVersionAction::ACTIONNAME_IGNORE,
+                            OnParentVersionAction::ACTIONNAME_ABORT,
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:configuration' => [
                 'name' => 'nt:configuration',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:versionable',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:versionable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:configuration',
                         'name' => 'jcr:root',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:file' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:file' => [
                 'name' => 'nt:file',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => 'jcr:content',
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:hierarchyNode',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:hierarchyNode',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:file',
                         'name' => 'jcr:content',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:folder' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:base',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:folder' => [
                 'name' => 'nt:folder',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:hierarchyNode',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:hierarchyNode',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:folder',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:hierarchyNode',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:frozenNode' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:hierarchyNode',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:frozenNode' => [
                 'name' => 'nt:frozenNode',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => 'jcr:frozenUuid',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => 'jcr:frozenPrimaryType',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => 'jcr:frozenMixinTypes',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:frozenNode',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:hierarchyNode' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:base',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:hierarchyNode' => [
                 'name' => 'nt:hierarchyNode',
                 'isAbstract' => true,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:created',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:linkedFile' =>
-            array(
+                'declaredSuperTypeNames' => [
+                    'mix:created',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:linkedFile' => [
                 'name' => 'nt:linkedFile',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => 'jcr:content',
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:hierarchyNode',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:hierarchyNode',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:linkedFile',
                         'name' => 'jcr:content',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:nodeType' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:nodeType' => [
                 'name' => 'nt:nodeType',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:hasOrderableChildNodes',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:isQueryable',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:isMixin',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:nodeTypeName',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:isAbstract',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    5 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:primaryItemName',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    6 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:supertypes',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:childNodeDefinition',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => 'nt:childNodeDefinition',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:childNodeDefinition',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:childNodeDefinition',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:nodeType',
                         'name' => 'jcr:propertyDefinition',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => 'nt:propertyDefinition',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:propertyDefinition',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:propertyDefinition' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:propertyDefinition',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:propertyDefinition' => [
                 'name' => 'nt:propertyDefinition',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:autoCreated',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:isQueryOrderable',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:protected',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:name',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:valueConstraints',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    5 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:isFullTextSearchable',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    6 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:onParentVersion',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'COPY',
-                            1 => 'VERSION',
-                            2 => 'INITIALIZE',
-                            3 => 'COMPUTE',
-                            4 => 'IGNORE',
-                            5 => 'ABORT',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    7 =>
-                    array(
+                        'valueConstraints' => [
+                            OnParentVersionAction::ACTIONNAME_COPY,
+                            OnParentVersionAction::ACTIONNAME_VERSION,
+                            OnParentVersionAction::ACTIONNAME_INITIALIZE,
+                            OnParentVersionAction::ACTIONNAME_COMPUTE,
+                            OnParentVersionAction::ACTIONNAME_IGNORE,
+                            OnParentVersionAction::ACTIONNAME_ABORT,
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:requiredType',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'STRING',
-                            1 => 'URI',
-                            2 => 'BINARY',
-                            3 => 'LONG',
-                            4 => 'DOUBLE',
-                            5 => 'DECIMAL',
-                            6 => 'BOOLEAN',
-                            7 => 'DATE',
-                            8 => 'NAME',
-                            9 => 'PATH',
-                            10 => 'REFERENCE',
-                            11 => 'WEAKREFERENCE',
-                            12 => 'UNDEFINED',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    8 =>
-                    array(
+                        'valueConstraints' => [
+                            'STRING',
+                            'URI',
+                            'BINARY',
+                            'LONG',
+                            'DOUBLE',
+                            'DECIMAL',
+                            'BOOLEAN',
+                            'DATE',
+                            'NAME',
+                            'PATH',
+                            'REFERENCE',
+                            'WEAKREFERENCE',
+                            'UNDEFINED',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:multiple',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    9 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:availableQueryOperators',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    10 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:defaultValues',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    11 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:propertyDefinition',
                         'name' => 'jcr:mandatory',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 6,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BOOLEAN,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:query' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:query' => [
                 'name' => 'nt:query',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:query',
                         'name' => 'jcr:statement',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:query',
                         'name' => 'jcr:language',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:resource'=>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:resource'=> [
                 'name' => 'nt:resource',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => 'jcr:data',
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:lastModified',
-                    1 => 'mix:mimeType',
-                    2 => 'mix:referenceable',
-                    3 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:lastModified',
+                    'mix:mimeType',
+                    'mix:referenceable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:resource',
                         'name' => 'jcr:data',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 2,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::BINARY,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:unstructured' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:unstructured' => [
                 'name' => 'nt:unstructured',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:unstructured',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:unstructured',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:unstructured',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => 'nt:unstructured',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:version' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:base',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:version' => [
                 'name' => 'nt:version',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:version',
                         'name' => 'jcr:predecessors',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:version',
                         'name' => 'jcr:activity',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:activity',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:activity',
+                        ],
+                        'availableQueryOperators' =>[
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:version',
                         'name' => 'jcr:created',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 5,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::DATE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:version',
                         'name' => 'jcr:successors',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:version',
                         'name' => 'jcr:frozenNode',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:frozenNode',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:versionHistory' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:frozenNode',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:versionHistory' => [
                 'name' => 'nt:versionHistory',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:versionHistory',
                         'name' => 'jcr:copiedFrom',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 10,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::WEAKREFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
+                        'valueConstraints' => [
                             0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:versionHistory',
                         'name' => 'jcr:versionableUuid',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:versionHistory',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:version',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:version',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:versionHistory',
                         'name' => 'jcr:versionLabels',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:versionLabels',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:versionLabels',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:versionLabels',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'nt:versionHistory',
                         'name' => 'jcr:rootVersion',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:version',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                    ),
-                ),
-            ),
-            'nt:versionLabels' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:version',
+                        ],
+                    ],
+                ],
+            ],
+            'nt:versionLabels' => [
                 'name' => 'nt:versionLabels',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:versionLabels',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:version',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'nt:versionedChild' =>
-            array(
+                        'valueConstraints' => [
+                            'nt:version',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'nt:versionedChild' => [
                 'name' => 'nt:versionedChild',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'nt:versionedChild',
                         'name' => 'jcr:childVersionHistory',
                         'isAutoCreated' => true,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'nt:versionHistory',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:ACE' =>
-            array(
+                        'valueConstraints' => [
+                            'nt:versionHistory',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:ACE' => [
                 'name' => 'rep:ACE',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:ACE',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:ACE',
                         'name' => 'rep:privileges',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 7,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::NAME,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:ACE',
                         'name' => 'rep:glob',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:ACE',
                         'name' => 'rep:nodePath',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 8,
+                        'onParentVersion' => PropertyType::STRING,
+                        'requiredType' => PropertyType::PATH,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:ACE',
                         'name' => 'rep:principalName',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:ACL' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:ACL' => [
                 'name' => 'rep:ACL',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:Policy',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'rep:Policy',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:ACL',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:GrantACE',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:ACE',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:AccessControl' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:ACE',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:AccessControl' => [
                 'name' => 'rep:AccessControl',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:AccessControl',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:AccessControl',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:AccessControl',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:AccessControl',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:PrincipalAccessControl',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:AccessControllable' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:PrincipalAccessControl',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:AccessControllable' => [
                 'name' => 'rep:AccessControllable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:AccessControllable',
                         'name' => 'rep:policy',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Policy',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:Activities' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Policy',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:Activities' => [
                 'name' => 'rep:Activities',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Activities',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:Activities',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Activities',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Activities',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:Activities',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:activity',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:activity',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:Authorizable' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:activity',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:Authorizable' => [
                 'name' => 'rep:Authorizable',
                 'isAbstract' => true,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'mix:referenceable',
-                    1 => 'nt:hierarchyNode',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'mix:referenceable',
+                    'nt:hierarchyNode',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Authorizable',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:Authorizable',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 1,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:Authorizable',
                         'name' => 'rep:principalName',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Authorizable',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:unstructured',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:AuthorizableFolder' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:base',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:AuthorizableFolder' => [
                 'name' => 'rep:AuthorizableFolder',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:hierarchyNode',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:hierarchyNode',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:AuthorizableFolder',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:AuthorizableFolder',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:AuthorizableFolder',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:AuthorizableFolder',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:AuthorizableFolder',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:User',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Authorizable',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:Configurations' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Authorizable',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:Configurations' => [
                 'name' => 'rep:Configurations',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Configurations',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:Configurations',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Configurations',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Configurations',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:Configurations',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:configuration',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:configuration',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:DenyACE' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:configuration',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:DenyACE' => [
                 'name' => 'rep:DenyACE',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:ACE',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:GrantACE' =>
-            array(
+                'declaredSuperTypeNames' => [
+                    'rep:ACE',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:GrantACE' => [
                 'name' => 'rep:GrantACE',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:ACE',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:Group' =>
-            array(
+                'declaredSuperTypeNames' => [
+                    'rep:ACE',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:Group' => [
                 'name' => 'rep:Group',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:Authorizable',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'rep:Authorizable',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Group',
                         'name' => 'rep:members',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 10,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::WEAKREFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
-                            0 => 'rep:Authorizable',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        'valueConstraints' => [
+                            'rep:Authorizable',
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Group',
                         'name' => 'rep:members',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 2,
+                        'onParentVersion' => OnParentVersionAction::VERSION,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => 'rep:Members',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Members',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:Impersonatable' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Members',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:Impersonatable' => [
                 'name' => 'rep:Impersonatable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Impersonatable',
                         'name' => 'rep:impersonators',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:Members' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:Members' => [
                 'name' => 'rep:Members',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Members',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 10,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::WEAKREFERENCE,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'valueConstraints' =>
-                        array(
+                        'valueConstraints' => [
                             0 => 'rep:Authorizable',
-                        ),
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                        ],
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:Members',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
                         'allowsSameNameSiblings' => true,
                         'defaultPrimaryTypeName' => 'rep:Members',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Members',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:Policy' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Members',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:Policy' => [
                 'name' => 'rep:Policy',
                 'isAbstract' => true,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:PrincipalAccessControl' =>
-            array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:PrincipalAccessControl' => [
                 'name' => 'rep:PrincipalAccessControl',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:AccessControl',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'rep:AccessControl',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:PrincipalAccessControl',
                         'name' => 'rep:policy',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Policy',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:RepoAccessControllable' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Policy',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:RepoAccessControllable' => [
                 'name' => 'rep:RepoAccessControllable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:RepoAccessControllable',
                         'name' => 'rep:repoPolicy',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => null,
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Policy',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:RetentionManageable' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Policy',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:RetentionManageable' => [
                 'name' => 'rep:RetentionManageable',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:RetentionManageable',
                         'name' => 'rep:retentionPolicy',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:RetentionManageable',
                         'name' => 'rep:hold',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 5,
-                        'requiredType' => 0,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
+                        'requiredType' => PropertyType::UNDEFINED,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:User' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:User' => [
                 'name' => 'rep:User',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'rep:Authorizable',
-                    1 => 'rep:Impersonatable',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'rep:Authorizable',
+                    'rep:Impersonatable',
+                ],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:User',
                         'name' => 'rep:password',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:User',
                         'name' => 'rep:disabled',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 1,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::STRING,
                         'multiple' => false,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:VersionReference' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:VersionReference' => [
                 'name' => 'rep:VersionReference',
                 'isAbstract' => false,
                 'isMixin' => true,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [],
+                'declaredPropertyDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:VersionReference',
                         'name' => 'rep:versions',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 1,
-                        'requiredType' => 9,
+                        'onParentVersion' => OnParentVersionAction::COPY,
+                        'requiredType' => PropertyType::REFERENCE,
                         'multiple' => true,
                         'fullTextSearchable' => true,
                         'queryOrderable' => true,
-                        'availableQueryOperators' =>
-                        array(
-                            0 => 'jcr.operator.equal.to',
-                            1 => 'jcr.operator.not.equal.to',
-                            2 => 'jcr.operator.greater.than',
-                            3 => 'jcr.operator.greater.than.or.equal.to',
-                            4 => 'jcr.operator.less.than',
-                            5 => 'jcr.operator.less.than.or.equal.to',
-                            6 => 'jcr.operator.like',
-                        ),
-                    ),
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                ),
-            ),
-            'rep:nodeTypes' =>
-            array(
+                        'availableQueryOperators' => [
+                            QOMConstantsInterface::JCR_OPERATOR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_NOT_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_GREATER_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN,
+                            QOMConstantsInterface::JCR_OPERATOR_LESS_THAN_OR_EQUAL_TO,
+                            QOMConstantsInterface::JCR_OPERATOR_LIKE,
+                        ],
+                    ],
+                ],
+                'declaredNodeDefinitions' => [],
+            ],
+            'rep:nodeTypes' => [
                 'name' => 'rep:nodeTypes',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:nodeTypes',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:nodeType',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:nodeType',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:root' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:nodeType',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:root' => [
                 'name' => 'rep:root',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:unstructured',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:unstructured',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:root',
                         'name' => 'jcr:system',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => false,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:system',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:system',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:system' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:system',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:system' => [
                 'name' => 'rep:system',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => true,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:system',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => false,
-                        'onParentVersion' => 5,
+                        'onParentVersion' => OnParentVersionAction::IGNORE,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:base',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:base',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:base',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:system',
                         'name' => 'jcr:versionStorage',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:versionStorage',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:versionStorage',
-                        ),
-                    ),
-                    2 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:versionStorage',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:system',
                         'name' => 'jcr:activities',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:Activities',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Activities',
-                        ),
-                    ),
-                    3 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Activities',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:system',
                         'name' => 'jcr:configurations',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:Configurations',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:Configurations',
-                        ),
-                    ),
-                    4 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:Configurations',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:system',
                         'name' => 'jcr:nodeTypes',
                         'isAutoCreated' => false,
                         'isMandatory' => true,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:nodeTypes',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:nodeTypes',
-                        ),
-                    ),
-                ),
-            ),
-            'rep:versionStorage' =>
-            array(
+                        'requiredPrimaryTypeNames' => [
+                            'rep:nodeTypes',
+                        ],
+                    ],
+                ],
+            ],
+            'rep:versionStorage' => [
                 'name' => 'rep:versionStorage',
                 'isAbstract' => false,
                 'isMixin' => false,
                 'isQueryable' => true,
                 'hasOrderableChildNodes' => false,
                 'primaryItemName' => null,
-                'declaredSuperTypeNames' =>
-                array(
-                    0 => 'nt:base',
-                ),
-                'declaredPropertyDefinitions' =>
-                array(
-                ),
-                'declaredNodeDefinitions' =>
-                array(
-                    0 =>
-                    array(
+                'declaredSuperTypeNames' => [
+                    'nt:base',
+                ],
+                'declaredPropertyDefinitions' => [],
+                'declaredNodeDefinitions' => [
+                    [
                         'declaringNodeType' => 'rep:versionStorage',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'nt:versionHistory',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'nt:versionHistory',
-                        ),
-                    ),
-                    1 =>
-                    array(
+                        'requiredPrimaryTypeNames' => [
+                            'nt:versionHistory',
+                        ],
+                    ],
+                    [
                         'declaringNodeType' => 'rep:versionStorage',
                         'name' => '*',
                         'isAutoCreated' => false,
                         'isMandatory' => false,
                         'isProtected' => true,
-                        'onParentVersion' => 6,
+                        'onParentVersion' => OnParentVersionAction::ABORT,
                         'allowsSameNameSiblings' => false,
                         'defaultPrimaryTypeName' => 'rep:versionStorage',
-                        'requiredPrimaryTypeNames' =>
-                        array(
-                            0 => 'rep:versionStorage',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        'requiredPrimaryTypeNames' => [
+                            'rep:versionStorage',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/src/Jackalope/Transport/TransportInterface.php
+++ b/src/Jackalope/Transport/TransportInterface.php
@@ -112,7 +112,7 @@ interface TransportInterface
      * Get the registered namespaces mappings from the backend.
      *
      * Returns all additional namespaces. Does not return the ones defined as
-     * constants in \PHPCR\NamespaceRegistryInterface
+     * constants in PHPCR\NamespaceRegistryInterface
      *
      * @return array Associative array of prefix => uri
      */
@@ -328,7 +328,7 @@ interface TransportInterface
      *
      * @see NodeTypeDefinition::fromArray
      */
-    public function getNodeTypes($nodeTypes = array());
+    public function getNodeTypes($nodeTypes = []);
 
     /**
      * Sets the depth with which a transport should fetch childnodes

--- a/src/Jackalope/Validation/Path/AbstractRegexValidator.php
+++ b/src/Jackalope/Validation/Path/AbstractRegexValidator.php
@@ -85,9 +85,7 @@ abstract class AbstractRegexValidator implements PathValidatorInterface
         $isMatch = 1 === preg_match($pattern, $path);
 
         if (false === $isMatch) {
-            throw new InvalidPathException(sprintf(
-                '"%s" does not match regexp "%s"', $path, $pattern
-            ));
+            throw new InvalidPathException(sprintf('"%s" does not match regexp "%s"', $path, $pattern));
         }
 
         return $isMatch;

--- a/src/Jackalope/Validation/Path/SimplePathValidator.php
+++ b/src/Jackalope/Validation/Path/SimplePathValidator.php
@@ -2,8 +2,6 @@
 
 namespace Jackalope\Validation\Path;
 
-use DOMElement;
-
 /**
  * Simple path validator
  *

--- a/src/Jackalope/Version/Version.php
+++ b/src/Jackalope/Version/Version.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope\Version;
 
+use InvalidArgumentException;
 use PHPCR\ItemNotFoundException;
 use PHPCR\NoSuchWorkspaceException;
 use PHPCR\PathNotFoundException;
@@ -27,13 +28,13 @@ class Version extends Node implements VersionInterface
      */
     public function getContainingHistory()
     {
-        return $this->objectManager->getNode($this->parentPath, '/', 'Version\\VersionHistory');
+        return $this->objectManager->getNode($this->parentPath, '/', VersionHistory::class);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws PathNotFoundException
      *
      * @api
@@ -46,7 +47,7 @@ class Version extends Node implements VersionInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws PathNotFoundException
      *
      * @api
@@ -64,13 +65,13 @@ class Version extends Node implements VersionInterface
         }
         $uuid = reset($successors);
 
-        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, Version::class);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws PathNotFoundException
      *
      * @api
@@ -82,10 +83,10 @@ class Version extends Node implements VersionInterface
          * with the objectManager
          */
         $successors = $this->getProperty("jcr:successors")->getString();
-        $results = array();
+        $results = [];
         foreach ($successors as $uuid) {
             // OPTIMIZE: use objectManager->getNodes instead of looping
-            $results[] = $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
+            $results[] = $this->objectManager->getNodeByIdentifier($uuid, Version::class);
         }
 
         return $results;
@@ -94,7 +95,7 @@ class Version extends Node implements VersionInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws PathNotFoundException
      * @throws ItemNotFoundException
      * @throws NoSuchWorkspaceException
@@ -114,7 +115,7 @@ class Version extends Node implements VersionInterface
         }
         $uuid = reset($predecessor);
 
-        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, Version::class);
     }
 
     /**
@@ -133,10 +134,10 @@ class Version extends Node implements VersionInterface
          * with the objectManager. see 3.13.2.6
          */
         $predecessors = $this->getProperty("jcr:predecessors")->getString();
-        $results = array();
+        $results = [];
         foreach ($predecessors as $uuid) {
             // OPTIMIZE: use objectManager->getNodes instead of looping
-            $results[] = $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
+            $results[] = $this->objectManager->getNodeByIdentifier($uuid, Version::class);
         }
 
         return $results;
@@ -172,7 +173,7 @@ class Version extends Node implements VersionInterface
     {
         // only set other versions dirty if they are cached, no need to load them from backend just to tell they need to be reloaded
         foreach ($this->getProperty('jcr:predecessors')->getString() as $preuuid) {
-            $pre = $this->objectManager->getCachedNodeByUuid($preuuid, 'Version\\Version');
+            $pre = $this->objectManager->getCachedNodeByUuid($preuuid, Version::class);
             if ($pre) {
                 $pre->setDirty();
             }
@@ -188,7 +189,7 @@ class Version extends Node implements VersionInterface
     {
         // only set other versions dirty if they are cached, no need to load them from backend just to tell they need to be reloaded
         foreach ($this->getProperty('jcr:successors')->getString() as $postuuid) {
-            $post = $this->objectManager->getCachedNodeByUuid($postuuid, 'Version\\Version');
+            $post = $this->objectManager->getCachedNodeByUuid($postuuid, Version::class);
             if ($post) {
                 $post->setDirty();
             }

--- a/src/Jackalope/Version/VersionHistory.php
+++ b/src/Jackalope/Version/VersionHistory.php
@@ -58,7 +58,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
      */
     public function getRootVersion()
     {
-        return $this->objectManager->getNode('jcr:rootVersion', $this->getPath(), 'Version\\Version');
+        return $this->objectManager->getNode('jcr:rootVersion', $this->getPath(), Version::class);
     }
 
     /**
@@ -89,7 +89,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
         // OPTIMIZE: special iterator that delays loading the versions
         if (!$this->versions) {
             $rootVersion = $this->getRootVersion();
-            $results = array($rootVersion->getName() => $rootVersion);
+            $results = [$rootVersion->getName() => $rootVersion];
             $this->versions = array_merge($results, $this->getEventualSuccessors($rootVersion));
         }
 
@@ -111,7 +111,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
     protected function getEventualSuccessors($node)
     {
         $successors = $node->getSuccessors();
-        $results = array();
+        $results = [];
         foreach ($successors as $successor) {
             $results[$successor->getName()] = $successor;
             // OPTIMIZE: use a stack instead of recursion
@@ -129,7 +129,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
     public function getAllLinearFrozenNodes()
     {
         // OPTIMIZE: special iterator that delays loading frozen nodes
-        $frozenNodes = array();
+        $frozenNodes = [];
         foreach ($this->getAllLinearVersions() as $version) {
             $frozenNodes[$version->getName()] = $version->getFrozenNode();
         }
@@ -145,7 +145,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
     public function getAllFrozenNodes()
     {
         // OPTIMIZE: special iterator that delays loading frozen nodes
-        $frozenNodes = array();
+        $frozenNodes = [];
         foreach ($this->getAllVersions() as $version) {
             $frozenNodes[$version->getName()] = $version->getFrozenNode();
         }
@@ -252,7 +252,7 @@ class VersionHistory extends Node implements VersionHistoryInterface
             throw new VersionException(sprintf('Version %s not found in history of %s', $version->getIdentifier(), $this->getPath()));
         }
 
-        $result = array();
+        $result = [];
         foreach ($this->versionLabels as $label => $labelVersion) {
             /* @var VersionInterface $labelVersion */
             if ($labelVersion->getIdentifier() == $version->getIdentifier()) {
@@ -274,14 +274,15 @@ class VersionHistory extends Node implements VersionHistoryInterface
             return;
         }
 
-        $this->versionLabels = array();
+        $this->versionLabels = [];
+
         $node = $this->getNode('jcr:versionLabels');
         foreach ($node->getProperties() as $property) {
             /* @var Property $property */
 
             if (NodeHelper::isSystemItem($node)) {
                 $name = $property->getName();
-                $value = $this->objectManager->getNodeByIdentifier($property->getValue()->getIdentifier(), 'Version\\Version');
+                $value = $this->objectManager->getNodeByIdentifier($property->getValue()->getIdentifier(), Version::class);
                 $this->versionLabels[$name] = $value;
             }
         }

--- a/src/Jackalope/Version/VersionManager.php
+++ b/src/Jackalope/Version/VersionManager.php
@@ -65,7 +65,7 @@ class VersionManager implements VersionManagerInterface
 
          $version = $this->objectManager->checkin($absPath);
          $version->setCachedPredecessorsDirty();
-         if ($history = $this->objectManager->getCachedNode(PathHelper::getParentPath($version->getPath()), 'Version\\VersionHistory')) {
+         if ($history = $this->objectManager->getCachedNode(PathHelper::getParentPath($version->getPath()), VersionHistory::class)) {
              $history->notifyHistoryChanged();
          }
          if ($node) {
@@ -138,7 +138,7 @@ class VersionManager implements VersionManagerInterface
             throw new UnsupportedRepositoryOperationException("Node at $absPath is not versionable");
         }
 
-        return $this->objectManager->getNodeByIdentifier($node->getProperty('jcr:versionHistory')->getString(), 'Version\\VersionHistory');
+        return $this->objectManager->getNodeByIdentifier($node->getProperty('jcr:versionHistory')->getString(), VersionHistory::class);
     }
 
     /**
@@ -171,7 +171,7 @@ class VersionManager implements VersionManagerInterface
             throw new UnsupportedRepositoryOperationException("No jcr:baseVersion version for $absPath");
         }
 
-        return $this->objectManager->getNodeByIdentifier($uuid, 'Version\\Version');
+        return $this->objectManager->getNodeByIdentifier($uuid, Version::class);
     }
 
     /**
@@ -213,7 +213,7 @@ class VersionManager implements VersionManagerInterface
         $this->objectManager->restore($removeExisting, $versionPath, $nodePath);
 
         $version->setCachedPredecessorsDirty();
-        if ($history = $this->objectManager->getCachedNode(PathHelper::getParentPath($version->getPath()), 'Version\\VersionHistory')) {
+        if ($history = $this->objectManager->getCachedNode(PathHelper::getParentPath($version->getPath()), VersionHistory::class)) {
             $history->notifyHistoryChanged();
         }
     }

--- a/tests/Jackalope/FactoryTest.php
+++ b/tests/Jackalope/FactoryTest.php
@@ -2,6 +2,9 @@
 
 namespace Jackalope;
 
+use InvalidArgumentException;
+use Other\TestDummy;
+
 class FactoryTest extends TestCase
 {
     /**
@@ -16,21 +19,20 @@ class FactoryTest extends TestCase
 
     public function testJackalope()
     {
-        $reg = $this->factory->get('NamespaceRegistry', array($this->getTransportStub()));
-        $this->assertInstanceOf('Jackalope\NamespaceRegistry', $reg);
+        $reg = $this->factory->get(NamespaceRegistry::class, [$this->getTransportStub()]);
+        $this->assertInstanceOf(NamespaceRegistry::class, $reg);
     }
 
     public function testOutside()
     {
-        $dummy = $this->factory->get('Other\TestDummy');
-        $this->assertInstanceOf('Other\TestDummy', $dummy);
+        $dummy = $this->factory->get(TestDummy::class);
+        $this->assertInstanceOf(TestDummy::class, $dummy);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testNotexisting()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->factory->get('ClassNotExisting');
     }
 }

--- a/tests/Jackalope/ImportExport/ImportExportTest.php
+++ b/tests/Jackalope/ImportExport/ImportExportTest.php
@@ -19,27 +19,27 @@ class ImportExportTest extends TestCase
      */
     public function testUnescapeXmlName($expectedOutput, $input)
     {
-        $this->assertEquals($expectedOutput, ImportExport::unescapeXmlName($input, array()));
+        $this->assertEquals($expectedOutput, ImportExport::unescapeXmlName($input, []));
     }
 
     public function escapeDataProvider()
     {
-        return array(
+        return [
             // The escaped characters
-            array(' ', '_x0020_'),
-            array('<', '_x003c_'),
-            array('>', '_x003e_'),
-            array('"', '_x0022_'),
-            array("'", '_x0027_'),
+            [' ', '_x0020_'],
+            ['<', '_x003c_'],
+            ['>', '_x003e_'],
+            ['"', '_x0022_'],
+            ["'", '_x0027_'],
             // Some test data from the JCR-specs
-            array('My Documents', 'My_x0020_Documents'),
-            array('My_Documents', 'My_Documents'),
-            array('My_x0020Documents', 'My_x005f_x0020Documents'),
-            array('My_x0020_Documents', 'My_x005f_x0020_Documents'),
-            array('My_x0020 Documents', 'My_x005f_x0020_x0020_Documents'),
+            ['My Documents', 'My_x0020_Documents'],
+            ['My_Documents', 'My_Documents'],
+            ['My_x0020Documents', 'My_x005f_x0020Documents'],
+            ['My_x0020_Documents', 'My_x005f_x0020_Documents'],
+            ['My_x0020 Documents', 'My_x005f_x0020_x0020_Documents'],
             // Some combinations
-            array('My "Documents"', 'My_x0020__x0022_Documents_x0022_'),
-            array("<My 'Documents'>", "_x003c_My_x0020__x0027_Documents_x0027__x003e_"),
-        );
+            ['My "Documents"', 'My_x0020__x0022_Documents_x0022_'],
+            ["<My 'Documents'>", "_x003c_My_x0020__x0027_Documents_x0027__x003e_"],
+        ];
     }
 }

--- a/tests/Jackalope/ItemTest.php
+++ b/tests/Jackalope/ItemTest.php
@@ -2,6 +2,10 @@
 
 namespace Jackalope;
 
+use PHPCR\ItemNotFoundException;
+use PHPCR\ItemVisitorInterface;
+use PHPCR\RepositoryException;
+
 class ItemTest extends TestCase
 {
     /**
@@ -10,7 +14,7 @@ class ItemTest extends TestCase
     protected function getItem($factory = null, $path = null, $session = null, $objectManager = null, $new = false)
     {
         if (! $factory) {
-            $factory = $this->getMockBuilder('Jackalope\FactoryInterface')->disableOriginalConstructor()->getMock();
+            $factory = $this->getMockBuilder(FactoryInterface::class)->disableOriginalConstructor()->getMock();
         }
         if (! $path) {
             $path = '/';
@@ -77,22 +81,20 @@ class ItemTest extends TestCase
         $this->assertSame('placeholder', $ancestor);
     }
 
-    /**
-     * @expectedException \PHPCR\ItemNotFoundException
-     */
     public function testGetAncestorTooDeep()
     {
+        $this->expectException(ItemNotFoundException::class);
+
         $item = $this->getItem(null, '/path/name');
-        $ancestor = $item->getAncestor(3);
+        $item->getAncestor(3);
     }
 
-    /**
-     * @expectedException \PHPCR\ItemNotFoundException
-     */
     public function testGetAncestorTooLow()
     {
+        $this->expectException(ItemNotFoundException::class);
+
         $item = $this->getItem(null, '/path/name');
-        $ancestor = $item->getAncestor(-1);
+        $item->getAncestor(-1);
     }
 
     public function testGetParent()
@@ -126,7 +128,7 @@ class ItemTest extends TestCase
     public function testAccept()
     {
         $item = $this->getItem();
-        $visitor = $this->getMock('\PHPCR\ItemVisitorInterface');
+        $visitor = $this->createMock(ItemVisitorInterface::class);
         $visitor->expects($this->once())
                 ->method('visit');
         $item->accept($visitor);
@@ -145,11 +147,10 @@ class ItemTest extends TestCase
         $this->assertTrue($item->isDeleted());
     }
 
-    /**
-     * @expectedException \PHPCR\RepositoryException
-     */
     public function testRemoveRoot()
     {
+        $this->expectException(RepositoryException::class);
+
         $item = $this->getItem(null, '/');
         $item->remove();
     }

--- a/tests/Jackalope/NodePathIteratorTest.php
+++ b/tests/Jackalope/NodePathIteratorTest.php
@@ -16,12 +16,12 @@ class NodePathIteratorTest extends TestCase
 
     public function provideIterator()
     {
-        return array(
-            array(array('/foo1'), 'Node', 'nt:foo', 2),
-            array(array('/foo1', '/foo2', '/foo3', '/foo4'), 'Node', 'nt:foo', 2),
-            array(array('/foo1', '/foo2', '/foo3', '/foo4', '/foo5'), 'Node', 'nt:foo', 2),
-            array(array('/foo1', '/foo2', '/foo3', '/foo4'), 'Node', 'nt:foo', 10),
-        );
+        return [
+            [['/foo1'], 'Node', 'nt:foo', 2],
+            [['/foo1', '/foo2', '/foo3', '/foo4'], 'Node', 'nt:foo', 2],
+            [['/foo1', '/foo2', '/foo3', '/foo4', '/foo5'], 'Node', 'nt:foo', 2],
+            [['/foo1', '/foo2', '/foo3', '/foo4'], 'Node', 'nt:foo', 10],
+        ];
     }
 
     /**
@@ -39,7 +39,7 @@ class NodePathIteratorTest extends TestCase
                 $me, $class, $filter, $batchSize
             ) {
                 $me->assertLessThanOrEqual($batchSize, count($cPaths));
-                $nodes = array();
+                $nodes = [];
                 $me->assertEquals($class, $cClass);
                 $me->assertEquals($filter, $cFilter);
                 foreach ($cPaths as $cPath) {
@@ -52,70 +52,70 @@ class NodePathIteratorTest extends TestCase
         $nodes = new NodePathIterator($this->objectManager, $paths, $class, $filter, $batchSize);
 
         foreach ($nodes as $node) {
-            $this->assertInstanceOf('Jackalope\Node', $node);
+            $this->assertInstanceOf(Node::class, $node);
         }
     }
 
     public function provideArrayAccess()
     {
-        return array(
+        return [
             // 1st target, batch size 2, 1 fetch
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 1, 'target' => 'p1'),
-            ),
+                ['nb_fetches' => 1, 'target' => 'p1'],
+            ],
 
             // 3rd target, batch size 2, 2 fetches
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 2, 'target' => 'p3'),
-            ),
+                ['nb_fetches' => 2, 'target' => 'p3'],
+            ],
 
             // 3rd target, batch size 1, 3 fetches
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 1,
-                array('nb_fetches' => 3, 'target' => 'p3'),
-            ),
+                ['nb_fetches' => 3, 'target' => 'p3'],
+            ],
 
             // test 0 paths
-            array(
-                array(),
+            [
+                [],
                 2,
-                array('nb_fetches' => 0),
-            ),
+                ['nb_fetches' => 0],
+            ],
 
             // test partial iteration
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 2, 'target' => 'p4', 'iterate_result' => 3)
-            ),
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+                ['nb_fetches' => 2, 'target' => 'p4', 'iterate_result' => 3]
+            ],
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 4, 'target' => 'p4', 'iterate_result' => 8)
-            ),
+                ['nb_fetches' => 4, 'target' => 'p4', 'iterate_result' => 8]
+            ],
 
             // multiple targets
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 3, 'target' => array('p1', 'p2', 'p3', 'p4', 'p5'))
-            ),
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+                ['nb_fetches' => 3, 'target' => ['p1', 'p2', 'p3', 'p4', 'p5']]
+            ],
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 2,
-                array('nb_fetches' => 4, 'target' => array('p8', 'p1'))
-            ),
-            array(
-                array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'),
+                ['nb_fetches' => 4, 'target' => ['p8', 'p1']]
+            ],
+            [
+                ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'],
                 100,
-                array('nb_fetches' => 1, 'target' => array('p8', 'p1'))
-            ),
-        );
+                ['nb_fetches' => 1, 'target' => ['p8', 'p1']]
+            ],
+        ];
     }
 
     /**
@@ -123,7 +123,7 @@ class NodePathIteratorTest extends TestCase
      */
     public function testArrayAccess($paths, $batchSize, $options)
     {
-        $options = array_merge(array(
+        $options = array_merge([
             // number of times we expect to call the getNodesByArray method
             'nb_fetches' => null,
 
@@ -132,13 +132,13 @@ class NodePathIteratorTest extends TestCase
 
             // if specified, iterate the RS this many times
             'iterate_result' => null,
-        ), $options);
+        ], $options);
 
         $nbFetches = $options['nb_fetches'];
         $targets = (array) $options['target'];
         $iterateResult = $options['iterate_result'];
 
-        $nodes = array();
+        $nodes = [];
         foreach ($paths as $path) {
             $node = $this->getNodeMock();
             $nodes[$path] = $node;
@@ -147,7 +147,7 @@ class NodePathIteratorTest extends TestCase
         $this->objectManager->expects($this->exactly($nbFetches))
             ->method('getNodesByPathAsArray')
             ->will($this->returnCallback(function ($paths) use ($nodes) {
-                $ret = array();
+                $ret = [];
                 foreach ($paths as $path) {
                     $ret[$path] = $nodes[$path];
                 }
@@ -168,7 +168,7 @@ class NodePathIteratorTest extends TestCase
             }
         }
 
-        $res = array();
+        $res = [];
         foreach ($targets as $target) {
             $res[$target] = $nodes[$target];
         }
@@ -179,53 +179,53 @@ class NodePathIteratorTest extends TestCase
      */
     public function testCount()
     {
-        $nodes = array();
-        $nodes2 = array();
-        foreach (array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7') as $name) {
+        $nodes = [];
+        $nodes2 = [];
+        foreach (['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'] as $name) {
             $nodes[$name] = $this->getNodeMock();
         }
-        foreach (array('p8') as $name) {
+        foreach (['p8'] as $name) {
             $nodes2[$name] = $this->getNodeMock();
         }
 
         $this->objectManager->expects($this->at(0))
             ->method('getNodesByPathAsArray')
-            ->with(array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'))
+            ->with(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'])
             ->will($this->returnValue($nodes))
         ;
         $this->objectManager->expects($this->at(1))
             ->method('getNodesByPathAsArray')
-            ->with(array('p8'))
+            ->with(['p8'])
             ->will($this->returnValue($nodes2))
         ;
 
-        $iterator = new NodePathIterator($this->objectManager, array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'), null, null, 7);
+        $iterator = new NodePathIterator($this->objectManager, ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'], null, null, 7);
         $this->assertCount(8, $iterator);
     }
 
     public function testSeek()
     {
-        $nodes = array();
-        $nodes2 = array();
-        foreach (array('p1', 'p2', 'p3') as $name) {
+        $nodes = [];
+        $nodes2 = [];
+        foreach (['p1', 'p2', 'p3'] as $name) {
             $nodes[$name] = $this->getNodeMock();
         }
-        foreach (array('p8', 'p9') as $name) {
+        foreach (['p8', 'p9'] as $name) {
             $nodes2[$name] = $this->getNodeMock();
         }
 
         $this->objectManager->expects($this->at(0))
             ->method('getNodesByPathAsArray')
-            ->with(array('p1', 'p2', 'p3'))
+            ->with(['p1', 'p2', 'p3'])
             ->will($this->returnValue($nodes))
         ;
         $this->objectManager->expects($this->at(1))
             ->method('getNodesByPathAsArray')
-            ->with(array('p8', 'p9'))
+            ->with(['p8', 'p9'])
             ->will($this->returnValue($nodes2))
         ;
 
-        $iterator = new NodePathIterator($this->objectManager, array('p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9'), null, null, 3);
+        $iterator = new NodePathIterator($this->objectManager, ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9'], null, null, 3);
         $iterator->seek(7);
         $iterator->valid();
 

--- a/tests/Jackalope/NodeTest.php
+++ b/tests/Jackalope/NodeTest.php
@@ -2,6 +2,9 @@
 
 namespace Jackalope;
 
+use ArrayIterator;
+use Iterator;
+
 class NodeTest extends TestCase
 {
     protected $JSON = '{":jcr:primaryType":"Name","jcr:primaryType":"rep:root","jcr:system":{},"tests_level1_access_base":{}}';
@@ -13,10 +16,10 @@ class NodeTest extends TestCase
         $objectManager = $this->getObjectManagerMock();
         $objectManager->expects($this->any())
             ->method('getNodesByPath')
-            ->will($this->returnValue(new \ArrayIterator(array(
-                "/jcr:root/tests_level1_access_base" => new Node($factory, json_decode($this->JSON), '/jcr:root/tests_level1_access_base', $session, $objectManager),
-                "/jcr:root/jcr:system" => new Node($factory, json_decode($this->JSON), '/jcr:root/jcr:system', $session, $objectManager),
-            ))))
+            ->will($this->returnValue(new ArrayIterator([
+                '/jcr:root/tests_level1_access_base' => new Node($factory, json_decode($this->JSON), '/jcr:root/tests_level1_access_base', $session, $objectManager),
+                '/jcr:root/jcr:system' => new Node($factory, json_decode($this->JSON), '/jcr:root/jcr:system', $session, $objectManager),
+            ])))
         ;
         $node = new Node($factory, json_decode($this->JSON), '/jcr:root', $session, $objectManager);
 
@@ -26,10 +29,10 @@ class NodeTest extends TestCase
     public function testConstructor()
     {
         $node = $this->createNode();
-        $this->assertInstanceOf('Jackalope\Session', $node->getSession());
-        $this->assertInstanceOf('Jackalope\Node', $node);
+        $this->assertInstanceOf(Session::class, $node->getSession());
+        $this->assertInstanceOf(Node::class, $node);
         $children = $node->getNodes();
-        $this->assertInstanceOf('Iterator', $children);
+        $this->assertInstanceOf(Iterator::class, $children);
         $this->assertCount(2, $children);
     }
 
@@ -44,7 +47,7 @@ class NodeTest extends TestCase
     public function testFilterNames()
     {
         $filter = 'test';
-        $names = array('test', 'toast');
+        $names = ['test', 'toast'];
         $filtered = NodeMock::filterNames($filter, $names);
         $this->assertInternalType('array', $filtered);
         $this->assertCount(1, $filtered);
@@ -76,7 +79,7 @@ class NodeTest extends TestCase
         $this->assertSame('test', $filtered[0]);
         $this->assertSame('toast', $filtered[1]);
 
-        $filter = array('test ', 'toa*');
+        $filter = ['test ', 'toa*'];
         $filtered = NodeMock::filterNames($filter, $names);
         $this->assertInternalType('array', $filtered);
         $this->assertCount(2, $filtered);
@@ -97,7 +100,7 @@ class NodeTest extends TestCase
         $this->assertSame('test', $filtered[0]);
         $this->assertSame('toast', $filtered[1]);
 
-        $filter = array('*');
+        $filter = ['*'];
         $filtered = NodeMock::filterNames($filter, $names);
         $this->assertInternalType('array', $filtered);
         $this->assertCount(2, $filtered);

--- a/tests/Jackalope/NodeType/NodeDefinitionTemplateTest.php
+++ b/tests/Jackalope/NodeType/NodeDefinitionTemplateTest.php
@@ -3,6 +3,7 @@
 namespace Jackalope\NodeType;
 
 use Jackalope\TestCase;
+use PHPCR\Version\OnParentVersionAction;
 
 class NodeDefinitionTemplateTest extends TestCase
 {
@@ -19,7 +20,7 @@ class NodeDefinitionTemplateTest extends TestCase
         $this->assertNull($ndt->getName());
         $this->assertFalse($ndt->isAutoCreated());
         $this->assertFalse($ndt->isMandatory());
-        $this->assertSame(\PHPCR\Version\OnParentVersionAction::COPY, $ndt->getOnParentVersion());
+        $this->assertSame(OnParentVersionAction::COPY, $ndt->getOnParentVersion());
         $this->assertFalse($ndt->isProtected());
         $this->assertNull($ndt->getRequiredPrimaryTypeNames());
         $this->assertNull($ndt->getDefaultPrimaryTypeName());

--- a/tests/Jackalope/NodeType/NodeTypeDefinitionTest.php
+++ b/tests/Jackalope/NodeType/NodeTypeDefinitionTest.php
@@ -2,33 +2,36 @@
 
 namespace Jackalope\NodeType;
 
+use DOMDocument;
+use InvalidArgumentException;
+use Jackalope\Factory;
 use Jackalope\TestCase;
 use PHPCR\PropertyType;
+use stdClass;
 
 class NodeTypeDefinitionTest extends TestCase
 {
-    /**
-     * @expectedException   \InvalidArgumentException
-     */
     public function testInvalidNodeTypeDefinition()
     {
-        $this->getNodeTypeManager()->createNodeTypeTemplate(new \stdclass);
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->getNodeTypeManager()->createNodeTypeTemplate(new stdClass());
     }
 
     public function testCreateFromArray()
     {
-        $factory = $this->getMock('Jackalope\Factory');
-        $typeDef = new NodeTypeDefinition($factory, $this->getNodeTypeManagerMock(), array(
-            'name'                      => 'test',
-            'isAbstract'                => true,
-            'isMixin'                   => true,
-            'isQueryable'               => true,
-            'hasOrderableChildNodes'    => true,
-            'primaryItemName'           => 'foo',
-            'supertypes'                => array(),
-            'declaredPropertyDefinitions' => array(),
-            'declaredNodeDefinitions'   => array(),
-        ));
+        $factory = $this->createMock(Factory::class);
+        $typeDef = new NodeTypeDefinition($factory, $this->getNodeTypeManagerMock(), [
+            'name'                        => 'test',
+            'isAbstract'                  => true,
+            'isMixin'                     => true,
+            'isQueryable'                 => true,
+            'hasOrderableChildNodes'      => true,
+            'primaryItemName'             => 'foo',
+            'supertypes'                  => [],
+            'declaredPropertyDefinitions' => [],
+            'declaredNodeDefinitions'     => [],
+        ]);
 
         $this->assertEquals('test', $typeDef->getName());
         $this->assertTrue($typeDef->isAbstract());
@@ -36,23 +39,23 @@ class NodeTypeDefinitionTest extends TestCase
         $this->assertTrue($typeDef->isQueryable());
         $this->assertTrue($typeDef->hasOrderableChildNodes());
         $this->assertEquals('foo', $typeDef->getPrimaryItemName());
-        $this->assertEquals(array(), $typeDef->getDeclaredSupertypeNames(), "Supertypes should be empty");
+        $this->assertEquals([], $typeDef->getDeclaredSupertypeNames(), 'Supertypes should be empty');
     }
 
     public function testCreateFromArrayFalse()
     {
-        $factory = $this->getMock('Jackalope\Factory');
-        $typeDef = new NodeTypeDefinition($factory, $this->getNodeTypeManagerMock(), array(
-            'name'                      => 'test',
-            'isAbstract'                => false,
-            'isMixin'                   => false,
-            'isQueryable'               => false,
-            'hasOrderableChildNodes'    => false,
-            'primaryItemName'           => 'foo',
-            'supertypes'                => array(),
-            'declaredPropertyDefinitions' => array(),
-            'declaredNodeDefinitions'   => array(),
-        ));
+        $factory = $this->createMock(Factory::class);
+        $typeDef = new NodeTypeDefinition($factory, $this->getNodeTypeManagerMock(), [
+            'name'                        => 'test',
+            'isAbstract'                  => false,
+            'isMixin'                     => false,
+            'isQueryable'                 => false,
+            'hasOrderableChildNodes'      => false,
+            'primaryItemName'             => 'foo',
+            'supertypes'                  => [],
+            'declaredPropertyDefinitions' => [],
+            'declaredNodeDefinitions'     => [],
+        ]);
 
         $this->assertFalse($typeDef->isAbstract());
         $this->assertFalse($typeDef->isMixin());
@@ -62,8 +65,8 @@ class NodeTypeDefinitionTest extends TestCase
 
     public function testCreateFromXml()
     {
-        $factory = new \Jackalope\Factory();
-        $dom = new \DOMDocument();
+        $factory = new Factory();
+        $dom = new DOMDocument();
         $dom->loadXML('<?xml version="1.0" encoding="UTF-8"?>
     <nodeType hasOrderableChildNodes="false" isAbstract="false" isMixin="true" isQueryable="true" name="mix:created">
         <propertyDefinition autoCreated="true" declaringNodeType="mix:created" fullTextSearchable="true" mandatory="false" multiple="false" name="jcr:createdBy" onParentVersion="COPY" protected="true" queryOrderable="true" requiredType="String">
@@ -112,7 +115,7 @@ class NodeTypeDefinitionTest extends TestCase
         $this->assertFalse($propertyDefinitions[0]->isMultiple());
         $this->assertTrue($propertyDefinitions[0]->isFullTextSearchable());
         $this->assertTrue($propertyDefinitions[0]->isQueryOrderable());
-        $this->assertEquals(array(
+        $this->assertEquals([
                 'jcr.operator.equal.to',
                 'jcr.operator.not.equal.to',
                 'jcr.operator.greater.than',
@@ -120,7 +123,7 @@ class NodeTypeDefinitionTest extends TestCase
                 'jcr.operator.less.than',
                 'jcr.operator.less.than.or.equal.to',
                 'jcr.operator.like',
-        ), $propertyDefinitions[0]->getAvailableQueryOperators());
+        ], $propertyDefinitions[0]->getAvailableQueryOperators());
 
         $this->assertEquals('jcr:created', $propertyDefinitions[1]->getName());
         $this->assertEquals(PropertyType::DATE, $propertyDefinitions[1]->getRequiredType());
@@ -129,7 +132,7 @@ class NodeTypeDefinitionTest extends TestCase
         $this->assertFalse($propertyDefinitions[1]->isMultiple());
         $this->assertTrue($propertyDefinitions[1]->isFullTextSearchable());
         $this->assertTrue($propertyDefinitions[1]->isQueryOrderable());
-        $this->assertEquals(array(
+        $this->assertEquals([
             'jcr.operator.equal.to',
             'jcr.operator.not.equal.to',
             'jcr.operator.greater.than',
@@ -137,6 +140,6 @@ class NodeTypeDefinitionTest extends TestCase
             'jcr.operator.less.than',
             'jcr.operator.less.than.or.equal.to',
             'jcr.operator.like',
-        ), $propertyDefinitions[1]->getAvailableQueryOperators());
+        ], $propertyDefinitions[1]->getAvailableQueryOperators());
     }
 }

--- a/tests/Jackalope/NodeType/NodeTypeManagerTest.php
+++ b/tests/Jackalope/NodeType/NodeTypeManagerTest.php
@@ -22,7 +22,7 @@ class NodeTypeManagerTest extends TestCase
     public function testGetNodeType()
     {
         $nt = $this->ntm->getNodeType('nt:file');
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $nt);
+        $this->assertInstanceOf(NodeType::class, $nt);
         $this->assertSame('nt:file', $nt->getName());
         $this->assertFalse($nt->isAbstract());
         $this->assertFalse($nt->isMixin());
@@ -38,11 +38,11 @@ class NodeTypeManagerTest extends TestCase
     public function testTypeHierarchies()
     {
         $nt = $this->ntm->getNodeType('nt:file');
-        $this->assertSame(array('nt:hierarchyNode'), $nt->getDeclaredSupertypeNames());
-        $this->assertEquals(array(), $this->ntm->getDeclaredSubtypes('nt:file'));
-        $this->assertEquals(array(), $this->ntm->getSubtypes('nt:file'));
-        $this->assertSame(array('nt:file', 'nt:folder', 'nt:linkedFile', 'rep:Authorizable', 'rep:AuthorizableFolder'), array_keys($this->ntm->getDeclaredSubtypes('nt:hierarchyNode')));
-        $this->assertSame(array('nt:file', 'nt:folder', 'nt:linkedFile', 'rep:Authorizable', 'rep:Group', 'rep:User', 'rep:AuthorizableFolder'), array_keys($this->ntm->getSubtypes('nt:hierarchyNode')));
+        $this->assertSame(['nt:hierarchyNode'], $nt->getDeclaredSupertypeNames());
+        $this->assertEquals([], $this->ntm->getDeclaredSubtypes('nt:file'));
+        $this->assertEquals([], $this->ntm->getSubtypes('nt:file'));
+        $this->assertSame(['nt:file', 'nt:folder', 'nt:linkedFile', 'rep:Authorizable', 'rep:AuthorizableFolder'], array_keys($this->ntm->getDeclaredSubtypes('nt:hierarchyNode')));
+        $this->assertSame(['nt:file', 'nt:folder', 'nt:linkedFile', 'rep:Authorizable', 'rep:Group', 'rep:User', 'rep:AuthorizableFolder'], array_keys($this->ntm->getSubtypes('nt:hierarchyNode')));
     }
 
     /**
@@ -59,14 +59,14 @@ class NodeTypeManagerTest extends TestCase
         $allNodes = $this->ntm->getAllNodeTypes();
         $this->assertInstanceOf('Iterator', $allNodes);
         $this->assertCount(52, $allNodes);
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $allNodes->current());
+        $this->assertInstanceOf(NodeType::class, $allNodes->current());
         $primaryNodes = $this->ntm->getPrimaryNodeTypes();
         $this->assertInstanceOf('Iterator', $primaryNodes);
         $this->assertCount(36, $primaryNodes);
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $primaryNodes->current());
+        $this->assertInstanceOf(NodeType::class, $primaryNodes->current());
         $mixinNodes = $this->ntm->getMixinNodeTypes();
         $this->assertInstanceOf('Iterator', $mixinNodes);
         $this->assertCount(16, $mixinNodes);
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $mixinNodes->current());
+        $this->assertInstanceOf(NodeType::class, $mixinNodes->current());
     }
 }

--- a/tests/Jackalope/NodeType/NodeTypeTemplateTest.php
+++ b/tests/Jackalope/NodeType/NodeTypeTemplateTest.php
@@ -17,7 +17,7 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeType\NodeTypeTemplate::__construct
+     * @covers \Jackalope\NodeType\NodeTypeTemplate::__construct
      */
     public function testCreateNodeTypeTemplateEmpty()
     {
@@ -25,7 +25,7 @@ class NodeTypeTemplateTest extends TestCase
 
         // is empty as defined by doc
         $this->assertNull($ntt->getName());
-        $this->assertSame(array('nt:base'), $ntt->getDeclaredSupertypeNames());
+        $this->assertSame(['nt:base'], $ntt->getDeclaredSupertypeNames());
         $this->assertFalse($ntt->isAbstract());
         $this->assertFalse($ntt->isMixin());
         $this->assertFalse($ntt->hasOrderableChildNodes());
@@ -36,16 +36,16 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeType\NodeTypeTemplate::__construct
-     * @covers Jackalope\NodeType\NodeTypeDefinition::fromNodeTypeDefinition
+     * @covers \Jackalope\NodeType\NodeTypeTemplate::__construct
+     * @covers \Jackalope\NodeType\NodeTypeDefinition::fromNodeTypeDefinition
      */
     public function testCreateNodeTypeTemplateFromDefinition()
     {
         $nt = $this->ntm->getNodeType('nt:file');
         $ntt = $this->ntm->createNodeTypeTemplate($nt);
 
-        $this->assertInstanceOf('Jackalope\NodeType\NodeTypeDefinition', $ntt);
-        $this->assertInstanceOf('Jackalope\NodeType\NodeTypeTemplate', $ntt);
+        $this->assertInstanceOf(NodeTypeDefinition::class, $ntt);
+        $this->assertInstanceOf(NodeTypeTemplate::class, $ntt);
         $this->assertSame($nt->getName(), $ntt->getName());
         $this->assertEquals($nt->isAbstract(), $ntt->isAbstract());
         $this->assertEquals($nt->isMixin(), $ntt->isMixin());
@@ -58,7 +58,7 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeTYpe\NodeTypeTemplate::getNodeDefinitionTemplates
+     * @covers \Jackalope\NodeTYpe\NodeTypeTemplate::getNodeDefinitionTemplates
      */
     public function testEmptyNodeTypeTemplatesMutable()
     {
@@ -80,7 +80,7 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeTYpe\NodeTypeTemplate::getNodeDefinitionTemplates
+     * @covers \Jackalope\NodeTYpe\NodeTypeTemplate::getNodeDefinitionTemplates
      */
     public function testNodeTypeTemplatesMutable()
     {
@@ -104,7 +104,7 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeTYpe\NodeTypeTemplate::getPropertyDefinitionTemplates
+     * @covers \Jackalope\NodeTYpe\NodeTypeTemplate::getPropertyDefinitionTemplates
      */
     public function testPropertyDefinitionTemplatesMutable()
     {
@@ -128,7 +128,7 @@ class NodeTypeTemplateTest extends TestCase
     }
 
     /**
-     * @covers Jackalope\NodeTYpe\NodeTypeTemplate::getPropertyDefinitionTemplates
+     * @covers \Jackalope\NodeTYpe\NodeTypeTemplate::getPropertyDefinitionTemplates
      */
     public function testEmptyPropertyDefinitionTemplatesMutable()
     {

--- a/tests/Jackalope/NodeType/NodeTypeTest.php
+++ b/tests/Jackalope/NodeType/NodeTypeTest.php
@@ -3,6 +3,9 @@
 namespace Jackalope\NodeType;
 
 use Jackalope\TestCase;
+use Iterator;
+use PHPCR\PropertyType;
+use PHPCR\Version\OnParentVersionAction;
 
 /**
  * Test the Node Type.
@@ -26,58 +29,61 @@ class NodeTypeTest extends TestCase
         $ntm = $this->getNodeTypeManager();
         $nt = $ntm->getNodeType('nt:configuration');
         $superTypes = $nt->getSupertypes();
-        $this->assertEquals(array("mix:versionable", "nt:base"), $nt->getDeclaredSupertypeNames());
+        $this->assertEquals(['mix:versionable', 'nt:base'], $nt->getDeclaredSupertypeNames());
         $this->assertCount(4, $superTypes);
 
-        $this->assertSame(array(
-            $ntm->getNodeType('mix:versionable'),
-            $ntm->getNodeType('mix:referenceable'),
-            $ntm->getNodeType('mix:simpleVersionable'),
-            $ntm->getNodeType('nt:base')),
+        $this->assertSame(
+            [
+                $ntm->getNodeType('mix:versionable'),
+                $ntm->getNodeType('mix:referenceable'),
+                $ntm->getNodeType('mix:simpleVersionable'),
+                $ntm->getNodeType('nt:base')
+            ],
             $superTypes
         );
-        $this->assertSame(array($ntm->getNodeType('mix:versionable'), $ntm->getNodeType('nt:base')), $nt->getDeclaredSupertypes());
+
+        $this->assertSame([$ntm->getNodeType('mix:versionable'), $ntm->getNodeType('nt:base')], $nt->getDeclaredSupertypes());
         $declaredSubTypes = $nt->getDeclaredSubtypes();
-        $this->assertInstanceOf('Iterator', $declaredSubTypes);
+        $this->assertInstanceOf(Iterator::class, $declaredSubTypes);
         $this->assertCount(0, $declaredSubTypes);
         $subTypes = $nt->getSubtypes();
-        $this->assertInstanceOf('Iterator', $subTypes);
+        $this->assertInstanceOf(Iterator::class, $subTypes);
         $this->assertCount(0, $subTypes);
         $this->assertTrue($nt->isNodeType('nt:configuration'));
         $this->assertTrue($nt->isNodeType('nt:base'));
         $this->assertTrue($nt->isNodeType('mix:simpleVersionable'));
         $this->assertFalse($nt->isNodeType('notanodetype'));
-        $expectedProperties = array('jcr:root', 'jcr:predecessors', 'jcr:configuration', 'jcr:activity', 'jcr:mergeFailed', 'jcr:versionHistory', 'jcr:baseVersion', 'jcr:uuid', 'jcr:isCheckedOut', 'jcr:mixinTypes', 'jcr:primaryType');
+        $expectedProperties = ['jcr:root', 'jcr:predecessors', 'jcr:configuration', 'jcr:activity', 'jcr:mergeFailed', 'jcr:versionHistory', 'jcr:baseVersion', 'jcr:uuid', 'jcr:isCheckedOut', 'jcr:mixinTypes', 'jcr:primaryType'];
         $this->assertCount(count($expectedProperties), $nt->getPropertyDefinitions());
         $i = 0;
         foreach ($nt->getPropertyDefinitions() as $propDef) {
-            $this->assertInstanceOf('Jackalope\NodeType\PropertyDefinition', $propDef);
+            $this->assertInstanceOf(PropertyDefinition::class, $propDef);
             $this->assertSame($expectedProperties[$i], $propDef->getName());
             $i++;
         }
-        $this->assertSame(array(), $nt->getChildNodeDefinitions());
+        $this->assertSame([], $nt->getChildNodeDefinitions());
 
         $nt = $ntm->getNodeType('nt:hierarchyNode');
         $declaredSubTypes = $nt->getDeclaredSubtypes();
-        $this->assertInstanceOf('Iterator', $declaredSubTypes);
+        $this->assertInstanceOf(Iterator::class, $declaredSubTypes);
         $this->assertCount(5, $declaredSubTypes);
         $subnode = $declaredSubTypes->current();
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $subnode);
+        $this->assertInstanceOf(NodeType::class, $subnode);
         $this->assertSame('nt:file', $subnode->getName());
         $subTypes = $nt->getSubtypes();
-        $this->assertInstanceOf('Iterator', $subTypes);
+        $this->assertInstanceOf(Iterator::class, $subTypes);
         $this->assertCount(7, $subTypes);
         $subTypes->seek(4);
         $subnode = $subTypes->current();
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $subnode);
+        $this->assertInstanceOf(NodeType::class, $subnode);
         $this->assertSame('rep:Group', $subnode->getName());
 
         $nt = $ntm->getNodeType('rep:PrincipalAccessControl');
-        $expectedChildNodes = array('rep:policy', '*', '*');
+        $expectedChildNodes = ['rep:policy', '*', '*'];
         $this->assertCount(count($expectedChildNodes), $nt->getChildNodeDefinitions());
         $i = 0;
         foreach ($nt->getChildNodeDefinitions() as $childNode) {
-            $this->assertInstanceOf('Jackalope\NodeType\NodeDefinition', $childNode);
+            $this->assertInstanceOf(NodeDefinition::class, $childNode);
             $this->assertSame($expectedChildNodes[$i], $childNode->getName());
             $i++;
         }
@@ -91,27 +97,27 @@ class NodeTypeTest extends TestCase
         $this->assertInternalType('array', $nodes);
         $this->assertCount(1, $nodes);
         $node = $nodes[0];
-        $this->assertInstanceOf('Jackalope\NodeType\NodeDefinition', $node);
+        $this->assertInstanceOf(NodeDefinition::class, $node);
         $this->assertSame('*', $node->getName());
-        $this->assertSame(array($ntm->getNodeType('nt:hierarchyNode')), $node->getRequiredPrimaryTypes());
-        $this->assertSame(array('nt:hierarchyNode'), $node->getRequiredPrimaryTypeNames());
-        $this->assertSame(null, $node->getDefaultPrimaryTypeName());
-        $this->assertSame(null, $node->getDefaultPrimaryType());
-        $this->assertSame(false, $node->allowsSameNameSiblings());
+        $this->assertSame([$ntm->getNodeType('nt:hierarchyNode')], $node->getRequiredPrimaryTypes());
+        $this->assertSame(['nt:hierarchyNode'], $node->getRequiredPrimaryTypeNames());
+        $this->assertNull($node->getDefaultPrimaryTypeName());
+        $this->assertNull($node->getDefaultPrimaryType());
+        $this->assertFalse($node->allowsSameNameSiblings());
 
         $nt = $ntm->getNodeType('nt:file');
         $nodes = $nt->getDeclaredChildNodeDefinitions();
         $this->assertInternalType('array', $nodes);
         $this->assertCount(1, $nodes);
         $node = $nodes[0];
-        $this->assertInstanceOf('Jackalope\NodeType\NodeDefinition', $node);
+        $this->assertInstanceOf(NodeDefinition::class, $node);
         $this->assertSame('jcr:content', $node->getName());
-        $this->assertSame(array($ntm->getNodeType('nt:base'), $ntm->getNodeType('nt:folder')), $node->getRequiredPrimaryTypes());
-        $this->assertSame(array('nt:base', 'nt:folder'), $node->getRequiredPrimaryTypeNames());
-        $this->assertSame(null, $node->getDefaultPrimaryTypeName());
-        $this->assertSame(null, $node->getDefaultPrimaryType());
+        $this->assertSame([$ntm->getNodeType('nt:base'), $ntm->getNodeType('nt:folder')], $node->getRequiredPrimaryTypes());
+        $this->assertSame(['nt:base', 'nt:folder'], $node->getRequiredPrimaryTypeNames());
+        $this->assertNull($node->getDefaultPrimaryTypeName());
+        $this->assertNull($node->getDefaultPrimaryType());
 
-        //Test defaultPrimaryType
+        // Test defaultPrimaryType
         $nt = $ntm->getNodeType('nt:nodeType');
         $nodes = $nt->getDeclaredChildNodeDefinitions();
         $this->assertCount(2, $nodes);
@@ -130,16 +136,16 @@ class NodeTypeTest extends TestCase
         $this->assertCount(0, $properties);
 
         $nt = $ntm->getNodeType('mix:created');
-        $this->assertInstanceOf('Jackalope\NodeType\NodeType', $nt);
+        $this->assertInstanceOf(NodeType::class, $nt);
         $this->assertSame('mix:created', $nt->getName());
-        $this->assertSame(array(), $nt->getDeclaredSupertypeNames());
+        $this->assertSame([], $nt->getDeclaredSupertypeNames());
         $this->assertFalse($nt->isAbstract());
         $this->assertTrue($nt->isMixin());
         $this->assertFalse($nt->hasOrderableChildNodes());
         $this->assertTrue($nt->isQueryable());
         $this->assertNull($nt->getPrimaryItemName());
 
-        //ItemDefinition
+        // ItemDefinition
         $properties = $nt->getDeclaredPropertyDefinitions();
         $this->assertInternalType('array', $properties);
         $this->assertCount(2, $properties);
@@ -148,22 +154,22 @@ class NodeTypeTest extends TestCase
         $this->assertSame('jcr:createdBy', $property->getName());
         $this->assertTrue($property->isAutoCreated());
         $this->assertFalse($property->isMandatory());
-        $this->assertSame(\PHPCR\Version\OnParentVersionAction::COPY, $property->getOnParentVersion());
+        $this->assertSame(OnParentVersionAction::COPY, $property->getOnParentVersion());
         $this->assertTrue($property->isProtected());
-        $this->assertSame(array(), $property->getDefaultValues());
+        $this->assertSame([], $property->getDefaultValues());
 
-        //PropertyDefinition
-        $this->assertSame(\PHPCR\PropertyType::STRING, $property->getRequiredType());
-        $this->assertSame(array(), $property->getValueConstraints());
+        // PropertyDefinition
+        $this->assertSame(PropertyType::STRING, $property->getRequiredType());
+        $this->assertSame([], $property->getValueConstraints());
         $this->assertFalse($property->isMultiple());
-        $this->assertSame(array('jcr.operator.equal.to', 'jcr.operator.not.equal.to', 'jcr.operator.greater.than', 'jcr.operator.greater.than.or.equal.to', 'jcr.operator.less.than', 'jcr.operator.less.than.or.equal.to', 'jcr.operator.like'), $property->getAvailableQueryOperators());
+        $this->assertSame(['jcr.operator.equal.to', 'jcr.operator.not.equal.to', 'jcr.operator.greater.than', 'jcr.operator.greater.than.or.equal.to', 'jcr.operator.less.than', 'jcr.operator.less.than.or.equal.to', 'jcr.operator.like'], $property->getAvailableQueryOperators());
         $this->assertTrue($property->isFullTextSearchable());
         $this->assertTrue($property->isQueryOrderable());
 
         $nt = $ntm->getNodeType('mix:versionable');
         $properties = $nt->getDeclaredPropertyDefinitions();
         $property = $properties[0];
-        $this->assertSame(array('nt:version'), $property->getValueConstraints());
+        $this->assertSame(['nt:version'], $property->getValueConstraints());
 
         $nt = $ntm->getNodeType('mix:simpleVersionable');
         $properties = $nt->getDeclaredPropertyDefinitions();

--- a/tests/Jackalope/NodeType/NodeTypeXmlConverterTest.php
+++ b/tests/Jackalope/NodeType/NodeTypeXmlConverterTest.php
@@ -2,6 +2,8 @@
 
 namespace Jackalope\NodeType;
 
+use DOMDocument;
+use DOMXPath;
 use Jackalope\TestCase;
 use Jackalope\Factory;
 
@@ -19,16 +21,16 @@ class NodeTypeXmlConverterTest extends TestCase
     {
         $data = $this->converter->getNodeTypeDefinitionFromXml($this->getNodeTypeDOMElement('nt:base'));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'nt:base',
             'isAbstract' => true,
             'isMixin' => false,
             'isQueryable' => true,
             'hasOrderableChildNodes' => true,
             'primaryItemName' => null,
-            'declaredSuperTypeNames' => array(),
-            'declaredPropertyDefinitions' => array(
-                array(
+            'declaredSuperTypeNames' => [],
+            'declaredPropertyDefinitions' => [
+                [
                     'declaringNodeType' => '',
                     'name' => 'jcr:primaryType',
                     'isAutoCreated' => true,
@@ -39,7 +41,8 @@ class NodeTypeXmlConverterTest extends TestCase
                     'multiple' => false,
                     'fullTextSearchable' => true,
                     'queryOrderable' => true,
-                ), array(
+                ],
+                [
                     'declaringNodeType' => '',
                     'name' => 'jcr:mixinTypes',
                     'isAutoCreated' => true,
@@ -50,26 +53,26 @@ class NodeTypeXmlConverterTest extends TestCase
                     'multiple' => true,
                     'fullTextSearchable' => true,
                     'queryOrderable' => true,
-                ),
-            ),
-            'declaredNodeDefinitions' => array(),
-        ), $data);
+                ],
+            ],
+            'declaredNodeDefinitions' => [],
+        ], $data);
     }
 
     public function testConvertNtUnstructured()
     {
         $data = $this->converter->getNodeTypeDefinitionFromXml($this->getNodeTypeDOMElement('nt:unstructured'));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'nt:unstructured',
             'isAbstract' => false,
             'isMixin' => false,
             'isQueryable' => true,
             'hasOrderableChildNodes' => true,
             'primaryItemName' => null,
-            'declaredSuperTypeNames' => array('nt:base'),
-            'declaredPropertyDefinitions' => array(
-                array(
+            'declaredSuperTypeNames' => ['nt:base'],
+            'declaredPropertyDefinitions' => [
+                [
                     'declaringNodeType' => 'nt:unstructured',
                     'name' => '*',
                     'isAutoCreated' => false,
@@ -80,10 +83,10 @@ class NodeTypeXmlConverterTest extends TestCase
                     'multiple' => true,
                     'fullTextSearchable' => true,
                     'queryOrderable' => true,
-                ),
-            ),
-            'declaredNodeDefinitions' => array(
-                array(
+                ],
+            ],
+            'declaredNodeDefinitions' => [
+                [
                     'declaringNodeType' => 'nt:unstructured',
                     'name' => '*',
                     'isAutoCreated' => false,
@@ -92,9 +95,10 @@ class NodeTypeXmlConverterTest extends TestCase
                     'onParentVersion' => 2,
                     'allowsSameNameSiblings' => false,
                     'defaultPrimaryTypeName' => 'nt:unstructured',
-                    'requiredPrimaryTypeNames' => array('nt:base'),
-                ),
-        )), $data);
+                    'requiredPrimaryTypeNames' => ['nt:base'],
+                ],
+            ]
+        ], $data);
     }
 
     public function getNodeTypeDOMElement($name)
@@ -156,13 +160,13 @@ class NodeTypeXmlConverterTest extends TestCase
 </nodeTypes>
 
 XML;
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXpath($dom);
+        $xpath = new DOMXpath($dom);
         $nodes = $xpath->evaluate('//nodeTypes/nodeType[@name="'.$name.'"]');
         if ($nodes->length != 1) {
-            $this->fail("Should have found exactly one element <nodeType> with name " . $name);
+            $this->fail("Should have found exactly one element <nodeType> with name $name");
         }
 
         return $nodes->item(0);

--- a/tests/Jackalope/NodeType/PropertyDefinitionTemplateTest.php
+++ b/tests/Jackalope/NodeType/PropertyDefinitionTemplateTest.php
@@ -3,6 +3,8 @@
 namespace Jackalope\NodeType;
 
 use Jackalope\TestCase;
+use PHPCR\PropertyType;
+use PHPCR\Version\OnParentVersionAction;
 
 class PropertyDefinitionTemplateTest extends TestCase
 {
@@ -19,9 +21,9 @@ class PropertyDefinitionTemplateTest extends TestCase
         $this->assertNull($ndt->getName());
         $this->assertFalse($ndt->isAutoCreated());
         $this->assertFalse($ndt->isMandatory());
-        $this->assertSame(\PHPCR\Version\OnParentVersionAction::COPY, $ndt->getOnParentVersion());
+        $this->assertSame(OnParentVersionAction::COPY, $ndt->getOnParentVersion());
         $this->assertFalse($ndt->isProtected());
-        $this->assertSame(\PHPCR\PropertyType::STRING, $ndt->getRequiredType());
+        $this->assertSame(PropertyType::STRING, $ndt->getRequiredType());
         $this->assertNull($ndt->getValueConstraints());
         $this->assertNull($ndt->getDefaultValues());
         $this->assertFalse($ndt->isMultiple());

--- a/tests/Jackalope/NodeType/PropertyDefinitionTest.php
+++ b/tests/Jackalope/NodeType/PropertyDefinitionTest.php
@@ -2,12 +2,13 @@
 
 namespace Jackalope\NodeType;
 
+use Jackalope\Factory;
 use Jackalope\TestCase;
 use PHPCR\Version\OnParentVersionAction;
 
 class PropertyDefinitionTest extends TestCase
 {
-    private $defaultData = array(
+    private $defaultData = [
         'declaringNodeType' => 'nt:unstructured',
         'name' => 'foo',
         'isAutoCreated' => false,
@@ -18,14 +19,14 @@ class PropertyDefinitionTest extends TestCase
         'multiple' => false,
         'fullTextSearchable' => false,
         'queryOrderable' => false,
-        'valueConstraints' => array(),
-        'availableQueryOperators' => array(),
+        'valueConstraints' => [],
+        'availableQueryOperators' => [],
         'defaultValues' => '',
-    );
+    ];
 
     public function testCreateFromArray()
     {
-        $factory = $this->getMock('Jackalope\Factory');
+        $factory = $this->createMock(Factory::class);
         $nodeTypeManager = $this->getNodeTypeManagerMock();
         $propType = new PropertyDefinition($factory, $this->defaultData, $nodeTypeManager);
 
@@ -42,8 +43,14 @@ class PropertyDefinitionTest extends TestCase
 
     public function testGetDeclaringNodeType()
     {
-        $nodeType = $this->getMock('Jackalope\NodeType\NodeTypeDefinition', array(), array(), '', false);
-        $factory = $this->getMock('Jackalope\Factory');
+        $nodeType = $this->getMockBuilder(NodeTypeDefinition::class)
+            ->setMethods([])
+            ->setConstructorArgs([])
+            ->setMockClassName('')
+            ->disableOriginalConstructor()
+        ;
+
+        $factory = $this->createMock(Factory::class);
         $nodeTypeManager = $this->getNodeTypeManagerMock();
         $nodeTypeManager
             ->expects($this->once())

--- a/tests/Jackalope/ObjectManagerTest.php
+++ b/tests/Jackalope/ObjectManagerTest.php
@@ -2,6 +2,9 @@
 
 namespace Jackalope;
 
+use DOMDocument;
+use Iterator;
+
 class ObjectManagerTest extends TestCase
 {
     /**
@@ -15,8 +18,8 @@ class ObjectManagerTest extends TestCase
         $session = $this->getSessionMock();
         $workspace = $session->getWorkspace();
 
-        $ntMock = $this->getNodeTypeMock(array('isNodeType' => true));
-        $ntmMock = $this->getNodeTypeManagerMock(array('getNodeType' => $ntMock));
+        $ntMock = $this->getNodeTypeMock(['isNodeType' => true]);
+        $ntmMock = $this->getNodeTypeManagerMock(['getNodeType' => $ntMock]);
 
         $workspace->expects($this->any())
             ->method('getNodeTypeManager')
@@ -29,9 +32,9 @@ class ObjectManagerTest extends TestCase
     {
         $path = '/jcr:root';
         $node = $this->om->getNodeByPath($path);
-        $this->assertInstanceOf('Jackalope\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
         $children = $node->getNodes();
-        $this->assertInstanceOf('Iterator', $children);
+        $this->assertInstanceOf(Iterator::class, $children);
         $this->assertCount(2, $children);
         $this->assertSame($node, $this->om->getNodeByPath($path));
     }
@@ -39,9 +42,9 @@ class ObjectManagerTest extends TestCase
     public function testGetNodeTypes()
     {
         $nodetypes = $this->om->getNodeTypes();
-        $this->assertInstanceOf('DOMDocument', $nodetypes);
-        $nodetypes = $this->om->getNodeTypes(array('nt:folder', 'nt:file'));
-        $this->assertInstanceOf('DOMDocument', $nodetypes);
+        $this->assertInstanceOf(DOMDocument::class, $nodetypes);
+        $nodetypes = $this->om->getNodeTypes(['nt:folder', 'nt:file']);
+        $this->assertInstanceOf(DOMDocument::class, $nodetypes);
     }
 
     public function testRegisterUuid()
@@ -49,7 +52,7 @@ class ObjectManagerTest extends TestCase
         $this->om->registerUuid('1234', '/jcr:root');
         $node = $this->om->getNodeByIdentifier('1234');
 
-        $this->assertInstanceOf('Jackalope\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
     }
 
     /**

--- a/tests/Jackalope/Observation/EventFilterAbsPathTest.php
+++ b/tests/Jackalope/Observation/EventFilterAbsPathTest.php
@@ -2,8 +2,6 @@
 
 namespace Jackalope\Observation;
 
-use Jackalope\Observation\Event;
-
 /**
  * Unit tests for the EventJournal
  */

--- a/tests/Jackalope/Observation/EventFilterEventTypeTest.php
+++ b/tests/Jackalope/Observation/EventFilterEventTypeTest.php
@@ -3,15 +3,13 @@
 namespace Jackalope\Observation;
 
 use PHPCR\Observation\EventInterface;
-use Jackalope\Observation\Event;
-use Jackalope\Observation\EventFilter;
 
 /**
  * Unit tests for the EventFilter
  */
 class EventFilterEventTypeTest extends EventFilterTestCase
 {
-    protected $allEventTypes = array(
+    protected $allEventTypes = [
         EventInterface::NODE_ADDED,
         EventInterface::NODE_MOVED,
         EventInterface::NODE_REMOVED,
@@ -19,13 +17,13 @@ class EventFilterEventTypeTest extends EventFilterTestCase
         EventInterface::PROPERTY_ADDED,
         EventInterface::PROPERTY_CHANGED,
         EventInterface::PROPERTY_REMOVED
-    );
+    ];
 
     public function testNoMatchFilter()
     {
         foreach ($this->allEventTypes as $type) {
             $this->eventFilter->setEventTypes(0);
-            $this->assertFilterMatch($this->eventFilter, array());
+            $this->assertFilterMatch($this->eventFilter, []);
         }
     }
 
@@ -33,15 +31,15 @@ class EventFilterEventTypeTest extends EventFilterTestCase
     {
         foreach ($this->allEventTypes as $type) {
             $this->eventFilter->setEventTypes($type);
-            $this->assertFilterMatch($this->eventFilter, array($type));
+            $this->assertFilterMatch($this->eventFilter, [$type]);
         }
     }
 
     public function testMultipleTypeFilter()
     {
-        $this->assertMultiTypeFilter(array(EventInterface::NODE_REMOVED, EventInterface::PROPERTY_REMOVED));
-        $this->assertMultiTypeFilter(array(EventInterface::PROPERTY_REMOVED, EventInterface::PROPERTY_ADDED, EventInterface::PROPERTY_CHANGED));
-        $this->assertMultiTypeFilter(array(EventInterface::NODE_REMOVED, EventInterface::NODE_ADDED, EventInterface::NODE_MOVED, EventInterface::PERSIST));
+        $this->assertMultiTypeFilter([EventInterface::NODE_REMOVED, EventInterface::PROPERTY_REMOVED]);
+        $this->assertMultiTypeFilter([EventInterface::PROPERTY_REMOVED, EventInterface::PROPERTY_ADDED, EventInterface::PROPERTY_CHANGED]);
+        $this->assertMultiTypeFilter([EventInterface::NODE_REMOVED, EventInterface::NODE_ADDED, EventInterface::NODE_MOVED, EventInterface::PERSIST]);
     }
 
     /**

--- a/tests/Jackalope/Observation/EventFilterIdentifiersTest.php
+++ b/tests/Jackalope/Observation/EventFilterIdentifiersTest.php
@@ -9,7 +9,7 @@ class EventFilterIdentifiersTest extends EventFilterTestCase
 {
     public function testFilter()
     {
-        $this->setFilters(array('1', '2', '3'));
+        $this->setFilters(['1', '2', '3']);
         $this->assertTrue($this->eventFilter->match($this->getEvent('/1/2', '1')));
         $this->assertTrue($this->eventFilter->match($this->getEvent('/2/2', '2')));
         $this->assertTrue($this->eventFilter->match($this->getEvent('/3/2', '3')));
@@ -19,9 +19,9 @@ class EventFilterIdentifiersTest extends EventFilterTestCase
 
     public function testNoMatchFilter()
     {
-        $this->eventFilter->setIdentifiers(array());
+        $this->eventFilter->setIdentifiers([]);
 
-        $nodes = array($this->getMyNodeMock('1'));
+        $nodes = [$this->getMyNodeMock('1')];
         $this->session
             ->expects($this->any())
             ->method('getNodesByIdentifier')
@@ -57,15 +57,18 @@ class EventFilterIdentifiersTest extends EventFilterTestCase
      */
     protected function setFilters($identifiers)
     {
-        $nodes = array();
+        $nodes = [];
+
         foreach ($identifiers as $uuid) {
             $nodes[] = $this->getMyNodeMock($uuid);
         }
+
         $this->session
             ->expects($this->any())
             ->method('getNodesByIdentifier')
             ->will($this->returnValue($nodes)
         );
+
         $this->eventFilter->setIdentifiers($identifiers);
     }
 

--- a/tests/Jackalope/Observation/EventFilterNodeTypeTest.php
+++ b/tests/Jackalope/Observation/EventFilterNodeTypeTest.php
@@ -4,6 +4,7 @@ namespace Jackalope\Observation;
 
 use Jackalope\Observation\Event;
 use Jackalope\Observation\EventFilter;
+use PHPCR\PathNotFoundException;
 
 /**
  * Unit tests for the EventFilter node type
@@ -26,7 +27,7 @@ class EventFilterNodeTypeTest extends EventFilterTestCase
             ->will($this->returnValue($node))
         ;
 
-        $this->eventFilter->setNodeTypes(array('nt:unstructured'));
+        $this->eventFilter->setNodeTypes(['nt:unstructured']);
         $this->assertFilterMatch($this->eventFilter, true);
     }
 
@@ -46,7 +47,7 @@ class EventFilterNodeTypeTest extends EventFilterTestCase
             ->will($this->returnValue($node))
         ;
 
-        $this->eventFilter->setNodeTypes(array('nt:unstructured'));
+        $this->eventFilter->setNodeTypes(['nt:unstructured']);
         $this->assertFilterMatch($this->eventFilter, false);
     }
 
@@ -56,9 +57,9 @@ class EventFilterNodeTypeTest extends EventFilterTestCase
             ->expects($this->any())
             ->method('getItem')
             ->with('/some/path')
-            ->will($this->throwException(new \PHPCR\PathNotFoundException()))
+            ->will($this->throwException(new PathNotFoundException()))
         ;
-        $this->eventFilter->setNodeTypes(array('nt:unstructured'));
+        $this->eventFilter->setNodeTypes(['nt:unstructured']);
         $this->assertFilterMatch($this->eventFilter, false);
     }
 

--- a/tests/Jackalope/Observation/EventFilterTest.php
+++ b/tests/Jackalope/Observation/EventFilterTest.php
@@ -17,9 +17,9 @@ class EventFilterTest extends EventFilterTestCase
         $this->assertEquals('/somepath', $this->eventFilter->getAbsPath());
         $this->eventFilter->setIsDeep(true);
         $this->assertTrue($this->eventFilter->getIsDeep());
-        $this->eventFilter->setIdentifiers(array('1', '2', '3'));
-        $this->assertEquals(array('1', '2', '3'), $this->eventFilter->getIdentifiers());
-        $this->eventFilter->setNodeTypes(array('nodeType'));
-        $this->assertEquals(array('nodeType'), $this->eventFilter->getNodeTypes());
+        $this->eventFilter->setIdentifiers(['1', '2', '3']);
+        $this->assertEquals(['1', '2', '3'], $this->eventFilter->getIdentifiers());
+        $this->eventFilter->setNodeTypes(['nodeType']);
+        $this->assertEquals(['nodeType'], $this->eventFilter->getNodeTypes());
     }
 }

--- a/tests/Jackalope/Observation/EventFilterTestCase.php
+++ b/tests/Jackalope/Observation/EventFilterTestCase.php
@@ -2,8 +2,9 @@
 
 namespace Jackalope\Observation;
 
+use Jackalope\FactoryInterface;
 use Jackalope\TestCase;
-use Jackalope\Observation\EventFilter;
+use PHPCR\SessionInterface;
 
 /**
  * Unit tests for the EventFilter
@@ -14,28 +15,32 @@ abstract class EventFilterTestCase extends TestCase
      * @var EventFilter
      */
     protected $eventFilter;
+
     /**
-     * @var \Jackalope\FactoryInterface
+     * @var FactoryInterface
      */
     protected $factory;
+
     /**
-     * @var \PHPCR\SessionInterface
+     * @var SessionInterface
      */
     protected $session;
 
     public function setUp()
     {
-        $this->factory = $this->getMock('Jackalope\\FactoryInterface');
+        $this->factory = $this->createMock(FactoryInterface::class);
+
         $this->session = $this->getSessionMock();
         $this->session
             ->expects($this->any())
             ->method('getNodes')
-            ->will($this->returnValue(array())
+            ->will($this->returnValue([])
         );
+
         $this->session
             ->expects($this->any())
             ->method('getNodesByIdentifier')
-            ->will($this->returnValue(array())
+            ->will($this->returnValue([])
         );
 
         $this->eventFilter = new EventFilter($this->factory, $this->session);

--- a/tests/Jackalope/Observation/EventJournalTest.php
+++ b/tests/Jackalope/Observation/EventJournalTest.php
@@ -2,25 +2,43 @@
 
 namespace Jackalope\Observation;
 
+use ArrayIterator;
+use Jackalope\FactoryInterface;
 use Jackalope\TestCase;
 use Jackalope\Factory;
+use Jackalope\Transport\TransportInterface;
+use PHPCR\Observation\EventJournalInterface;
+use PHPCR\SessionInterface;
+use Jackalope\Transport\ObservationInterface;
 
 /**
  * Unit tests for the EventJournal
  */
 class EventJournalTest extends TestCase
 {
+    /**
+     * @var FactoryInterface
+     */
     protected $factory;
 
+    /**
+     * @var EventJournalInterface
+     */
     protected $journal;
 
+    /**
+     * @var SessionInterface
+     */
     protected $session;
 
+    /**
+     * @var TransportInterface
+     */
     protected $transport;
 
     public function setUp()
     {
-        $this->session = $this->getSessionMock(array('getNode', 'getNodesByIdentifier'));
+        $this->session = $this->getSessionMock(['getNode', 'getNodesByIdentifier']);
         $this->session
             ->expects($this->any())
             ->method('getNode')
@@ -28,10 +46,10 @@ class EventJournalTest extends TestCase
         $this->session
             ->expects($this->any())
             ->method('getNodesByIdentifier')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
         $this->factory = new Factory();
 
-        $this->transport = $this->getMock('\Jackalope\Transport\ObservationInterface');
+        $this->transport = $this->createMock(ObservationInterface::class);
     }
 
     public function testConstructor()
@@ -59,7 +77,7 @@ class EventJournalTest extends TestCase
 
         $journal = new EventJournal($this->factory, $filter, $this->session, $this->transport);
 
-        $this->getAndCallMethod($journal, 'fetchJournal', array());
+        $this->getAndCallMethod($journal, 'fetchJournal', []);
         $this->myAssertAttributeEquals('test', 'events', $journal);
     }
 
@@ -77,7 +95,7 @@ class EventJournalTest extends TestCase
         $journal = new EventJournal($this->factory, $filter, $this->session, $this->transport);
         $journal->skipTo(2);
 
-        $this->getAndCallMethod($journal, 'fetchJournal', array());
+        $this->getAndCallMethod($journal, 'fetchJournal', []);
         $this->myAssertAttributeEquals('test-data', 'events', $journal);
     }
 
@@ -95,7 +113,7 @@ class EventJournalTest extends TestCase
             ->method('getEvents')
             ->with(2, $filter, $this->session)
             ->will($this->returnValue(
-                new \ArrayIterator(array($event1, $event2))
+                new ArrayIterator([$event1, $event2])
             ))
         ;
 

--- a/tests/Jackalope/PropertyTest.php
+++ b/tests/Jackalope/PropertyTest.php
@@ -2,32 +2,34 @@
 
 namespace Jackalope;
 
+use ArrayObject;
 use PHPCR\PropertyType;
+use PHPCR\RepositoryException;
 
 class PropertyTest extends TestCase
 {
     public function provideGetNode()
     {
-        return array(
-            array(
-                array('1234-1234', '4321-4321'),
-                array(),
+        return [
+            [
+                ['1234-1234', '4321-4321'],
+                [],
                 'Internal Error: Could not find one or more referenced nodes: "1234-1234", "4321-4321". If the referencing node is a frozen version, this can happen, otherwise it would be a bug.',
-            ),
-            array(
-                array('1234-1234', '4321-4321'),
-                array('1234-1234'),
+            ],
+            [
+                ['1234-1234', '4321-4321'],
+                ['1234-1234'],
                 'Internal Error: Could not find one or more referenced nodes: "4321-4321". If the referencing node is a frozen version, this can happen, otherwise it would be a bug.',
-            ),
-            array(
-                array('1234-1234', '4321-4321'),
-                array('1234-1234', '4321-4321'),
-            ),
-            array(
-                array('1234-1234', '4321-4321'),
-                array('4321-4321', '1234-1234'),
-            ),
-        );
+            ],
+            [
+                ['1234-1234', '4321-4321'],
+                ['1234-1234', '4321-4321'],
+            ],
+            [
+                ['1234-1234', '4321-4321'],
+                ['4321-4321', '1234-1234'],
+            ],
+        ];
     }
 
     /**
@@ -36,10 +38,11 @@ class PropertyTest extends TestCase
     public function testGetNode($values, $nodeUuids, $exceptionMessage = null)
     {
         if ($exceptionMessage) {
-            $this->setExpectedException('PHPCR\RepositoryException', $exceptionMessage);
+            $this->expectException(RepositoryException::class);
+            $this->expectExceptionMessage($exceptionMessage);
         }
 
-        $nodes = new \ArrayObject();
+        $nodes = new ArrayObject();
 
         foreach ($nodeUuids as $nodeUuid) {
             $nodes[$nodeUuid] = $this->getNodeMock();
@@ -50,14 +53,14 @@ class PropertyTest extends TestCase
             ;
         }
 
-        $data = array(
-            'type' => PropertyType::REFERENCE, 'value' => $values,
-        );
+        $data = ['type' => PropertyType::REFERENCE, 'value' => $values];
+
         $factory = new Factory();
         $session = $this->getSessionMock();
-        $objectManager = $this->getObjectManagerMock(array(
+        $objectManager = $this->getObjectManagerMock([
             'getNodesByIdentifier' => $nodes
-        ));
+        ]);
+
         $property = new Property($factory, $data, '/path/to', $session, $objectManager);
         $property->getNode();
     }

--- a/tests/Jackalope/Query/QOM/QomToSql1QueryConverterTest.php
+++ b/tests/Jackalope/Query/QOM/QomToSql1QueryConverterTest.php
@@ -2,17 +2,19 @@
 
 namespace Jackalope\Query\QOM;
 
-use Jackalope\Query\QOM\QueryObjectModelFactory;
 use Jackalope\Factory;
 use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
 use PHPCR\Util\QOM\QueryBuilder;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as Constants;
 use PHPCR\Query\QOM\ConstraintInterface;
 use PHPCR\Query\QOM\SourceInterface;
+use PHPUnit_Framework_TestCase;
 
-class QomToSql1QueryConverterTest extends \PHPUnit_Framework_TestCase
+class QomToSql1QueryConverterTest extends PHPUnit_Framework_TestCase
 {
-    /** @var QueryObjectModelFactoryInterface */
+    /**
+     * @var QueryObjectModelFactoryInterface
+     */
     protected $qf;
     protected $qb;
 
@@ -32,25 +34,25 @@ class QomToSql1QueryConverterTest extends \PHPUnit_Framework_TestCase
 
     public function testFullText()
     {
-        $statement = $this->doQuery($this->qf->fullTextSearch('base', "foo", "bar"));
+        $statement = $this->doQuery($this->qf->fullTextSearch('base', 'foo', 'bar'));
         $this->assertSame("SELECT s FROM nt:base WHERE CONTAINS(foo, 'bar')", $statement);
     }
 
     public function testDescendantNode()
     {
-        $statement = $this->doQuery($this->qf->descendantNode('base', "/foo/bar"));
+        $statement = $this->doQuery($this->qf->descendantNode('base', '/foo/bar'));
         $this->assertSame("SELECT s FROM nt:base WHERE jcr:path LIKE '/foo[%]/bar[%]/%'", $statement);
     }
 
     public function testPpropertyExistence()
     {
-        $statement = $this->doQuery($this->qf->propertyExistence('base', "foo"));
+        $statement = $this->doQuery($this->qf->propertyExistence('base', 'foo'));
         $this->assertSame("SELECT s FROM nt:base WHERE foo IS NOT NULL", $statement);
     }
 
     public function testChildNode()
     {
-        $statement = $this->doQuery($this->qf->childNode('base', "/foo/bar"));
+        $statement = $this->doQuery($this->qf->childNode('base', '/foo/bar'));
         $this->assertSame("SELECT s FROM nt:base WHERE jcr:path LIKE '/foo[%]/bar[%]/%' AND NOT jcr:path LIKE '/foo[%]/bar[%]/%/%'", $statement);
     }
 
@@ -58,10 +60,10 @@ class QomToSql1QueryConverterTest extends \PHPUnit_Framework_TestCase
     {
         $this->qb->andWhere($this->qf->comparison($this->qf->propertyValue('base', 'foo'), Constants::JCR_OPERATOR_EQUAL_TO, $this->qf->literal('bar')));
         $statement = $this->doQuery($this->qf->propertyExistence('base', "foo"));
-        $variations = array(
+        $variations = [
             "SELECT s FROM nt:base WHERE foo = 'bar' AND foo IS NOT NULL",
             "SELECT s FROM nt:base WHERE (foo = 'bar' AND foo IS NOT NULL)",
-        );
+        ];
         $this->assertTrue(in_array($statement, $variations), "The statement '$statement' does not match an expected variation");
     }
 
@@ -71,10 +73,10 @@ class QomToSql1QueryConverterTest extends \PHPUnit_Framework_TestCase
         $this->qb->orWhere($this->qf->comparison($this->qf->propertyValue('base', 'bar'), Constants::JCR_OPERATOR_EQUAL_TO, $this->qf->literal('foo')));
         $this->qb->from($this->qf->selector('base', "nt:base"));
         $statement = $this->qb->getQuery()->getStatement();
-        $variations = array(
+        $variations = [
             "SELECT s FROM nt:base WHERE foo = 'bar' OR bar = 'foo'",
             "SELECT s FROM nt:base WHERE (foo = 'bar' OR bar = 'foo')",
-        );
+        ];
         $this->assertTrue(in_array($statement, $variations), "The statement '$statement' does not match an expected variation");
     }
 
@@ -87,13 +89,13 @@ class QomToSql1QueryConverterTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        $this->qb->from($this->qf->selector('base', "nt:base"));
+        $this->qb->from($this->qf->selector('base', 'nt:base'));
         $statement = $this->qb->getQuery()->getStatement();
 
-        $variations = array(
+        $variations = [
             "SELECT s FROM nt:base WHERE NOT bar = 'foo'",
             "SELECT s FROM nt:base WHERE (NOT bar = 'foo')",
-        );
+        ];
         $this->assertTrue(in_array($statement, $variations), "The statement '$statement' does not match an expected variation");
     }
 }
@@ -107,11 +109,11 @@ class QueryObjectModelFactorySql1 extends QueryObjectModelFactory
     */
     public function createQuery(SourceInterface $source,
                         ConstraintInterface $constraint = null,
-                        array $orderings = array(),
-                        array $columns = array(),
+                        array $orderings = [],
+                        array $columns = [],
                         $simpleQuery = false
         ) {
-        return $this->factory->get('Query\QOM\QueryObjectModelSql1',
-        array($this->objectManager, $source, $constraint, $orderings, $columns));
+        return $this->factory->get(QueryObjectModelSql1::class,
+        [$this->objectManager, $source, $constraint, $orderings, $columns]);
     }
 }

--- a/tests/Jackalope/Query/SqlQueryTest.php
+++ b/tests/Jackalope/Query/SqlQueryTest.php
@@ -4,6 +4,8 @@ namespace Jackalope\Query;
 
 use Jackalope\TestCase;
 use Jackalope\Factory;
+use Jackalope\Transport\QueryInterface;
+use PHPCR\ItemNotFoundException;
 
 class SqlQueryTest extends TestCase
 {
@@ -12,7 +14,7 @@ class SqlQueryTest extends TestCase
     protected function getQuery($factory = null, $statement = null, $objectManager = null, $path = null)
     {
         if (! $factory) {
-            $factory = new Factory;
+            $factory = new Factory();
         }
         if (! $statement) {
             $statement = $this->statement;
@@ -32,8 +34,9 @@ class SqlQueryTest extends TestCase
     public function testExecute()
     {
         $dummyData = 'x';
-        $factory = $this->getMock('\Jackalope\Factory');
-        $transport = $this->getMock('\Jackalope\Transport\QueryInterface');
+        $factory = $this->createMock(Factory::class);
+        $transport = $this->createMock(QueryInterface::class);
+
         $om = $this->getObjectManagerMock();
         $om->expects($this->any())
             ->method('getTransport')
@@ -45,11 +48,14 @@ class SqlQueryTest extends TestCase
         $transport->expects($this->once())
             ->method('query')
             ->with($query)
-            ->will($this->returnValue($dummyData));
+            ->will($this->returnValue($dummyData))
+        ;
+
         $factory->expects($this->once())
                 ->method('get')
-                ->with('Query\QueryResult', array($dummyData, $om))
-                ->will($this->returnValue('result'));
+                ->with(QueryResult::class, [$dummyData, $om])
+                ->will($this->returnValue('result'))
+        ;
 
         $result = $query->execute();
         $this->assertEquals('result', $result);
@@ -98,11 +104,10 @@ class SqlQueryTest extends TestCase
         $this->assertSame('/path/query', $query->getStoredQueryPath());
     }
 
-    /**
-     * @expectedException \PHPCR\ItemNotFoundException
-     */
     public function testGetStoredQueryPathNotStored()
     {
+        $this->expectException(ItemNotFoundException::class);
+
         $query = $this->getQuery();
         $query->getStoredQueryPath();
     }

--- a/tests/Jackalope/RepositoryTest.php
+++ b/tests/Jackalope/RepositoryTest.php
@@ -18,14 +18,14 @@ class RepositoryTest extends TestCase
             ->will($this->returnValue(true));
         $transport->expects($this->once())
             ->method('getRepositoryDescriptors')
-            ->will($this->returnValue(array('bla'=>'bli')));
+            ->will($this->returnValue(['bla' => 'bli']));
         $transport->expects($this->any())
             ->method('getNamespaces')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $repo = new Repository($factory, $transport);
         $session = $repo->login($credentials, $workspaceName);
-        $this->assertInstanceOf('Jackalope\Session', $session);
+        $this->assertInstanceOf(Session::class, $session);
 
         $this->assertContains('bla', $repo->getDescriptorKeys());
         $this->assertSame('bli', $repo->getDescriptor('bla'));

--- a/tests/Jackalope/SessionTest.php
+++ b/tests/Jackalope/SessionTest.php
@@ -8,7 +8,7 @@ class SessionTest extends TestCase
 {
     public function testConstructor()
     {
-        $factory = new Factory;
+        $factory = new Factory();
         $repository = $this->getRepositoryMock();
         $workspaceName = 'asdfads';
         $userID = 'abcd';
@@ -18,18 +18,18 @@ class SessionTest extends TestCase
         $transport = $this->getTransportStub();
         $transport->expects($this->any())
             ->method('getNamespaces')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
         $s = new Session($factory, $repository, $workspaceName, $cred, $transport);
         $this->assertSame($repository, $s->getRepository());
         $this->assertSame($userID, $s->getUserID());
-        $this->assertSame(array('test', 'other'), $s->getAttributeNames());
+        $this->assertSame(['test', 'other'], $s->getAttributeNames());
         $this->assertSame('toast', $s->getAttribute('test'));
         $this->assertSame('value', $s->getAttribute('other'));
     }
 
     public function testLogoutAndRegistry()
     {
-        $factory = new Factory;
+        $factory = new Factory();
         $repository = $this->getRepositoryMock();
         $transport = $this->getTransportStub();
         $transport->expects($this->once())
@@ -50,7 +50,8 @@ class SessionTest extends TestCase
         $transport = $this->getTransportStub();
         $transport->expects($this->any())
             ->method('getNamespaces')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
+
         $s = new Session($factory, $repository, 'workspaceName', new SimpleCredentials('foo', 'bar'), $transport);
 
         $this->assertSame(Session::getSessionFromRegistry($s->getRegistryKey()), $s);

--- a/tests/Jackalope/Validation/Path/JackrabbitPathValidatorTest.php
+++ b/tests/Jackalope/Validation/Path/JackrabbitPathValidatorTest.php
@@ -2,9 +2,6 @@
 
 namespace Jackalope\NodeType\Path;
 
-use Jackalope\NodeType\NodeProcessor;
-use Jackalope\TestCase;
-use PHPCR\PropertyType;
 use Jackalope\Validation\PathValidatorTestCase;
 use Jackalope\Validation\Path\JackrabbitPathValidator;
 
@@ -17,7 +14,7 @@ class JackrabbitPathValidatorTest extends PathValidatorTestCase
 
     public function getPathAnswers()
     {
-        return array(
+        return [
             'absolute_1' => true,
             'absolute_2' => false,
             'absolute_3' => false,
@@ -35,12 +32,12 @@ class JackrabbitPathValidatorTest extends PathValidatorTestCase
             'normal_12' => false,
             'normal_13' => false,
             'normal_14' => false,
-        );
+        ];
     }
 
     public function getNameAnswers()
     {
-        return array(
+        return [
             'normal_1' => false,
             'normal_2' => false,
             'normal_3' => true,
@@ -61,6 +58,6 @@ class JackrabbitPathValidatorTest extends PathValidatorTestCase
             'localname_3' => true,
             'localname_4' => true,
             'localname_5' => true,
-        );
+        ];
     }
 }

--- a/tests/Jackalope/Validation/Path/SimplePathValidatorTest.php
+++ b/tests/Jackalope/Validation/Path/SimplePathValidatorTest.php
@@ -17,7 +17,7 @@ class SimplePathValidatorTest extends PathValidatorTestCase
 
     public function getPathAnswers()
     {
-        return array(
+        return [
             'absolute_1' => true,
             'absolute_2' => false,
             'absolute_3' => false,
@@ -35,12 +35,12 @@ class SimplePathValidatorTest extends PathValidatorTestCase
             'normal_12' => false,
             'normal_13' => false,
             'normal_14' => false,
-        );
+        ];
     }
 
     public function getNameAnswers()
     {
-        return array(
+        return [
             'normal_1' => false,
             'normal_2' => false,
             'normal_3' => true,
@@ -61,6 +61,6 @@ class SimplePathValidatorTest extends PathValidatorTestCase
             'localname_3' => false,
             'localname_4' => false,
             'localname_5' => false,
-        );
+        ];
     }
 }

--- a/tests/Jackalope/Validation/PathValidatorTestCase.php
+++ b/tests/Jackalope/Validation/PathValidatorTestCase.php
@@ -2,10 +2,10 @@
 
 namespace Jackalope\Validation;
 
-use Jackalope\NodeType\NodeProcessor;
+use InvalidArgumentException;
 use Jackalope\TestCase;
-use PHPCR\PropertyType;
-use Jackalope\Validation\JackrabbitPathValidator;
+use Jackalope\Validation\Exception\InvalidPathException;
+use PHPCR\ValueFormatException;
 
 abstract class PathValidatorTestCase extends TestCase
 {
@@ -17,28 +17,28 @@ abstract class PathValidatorTestCase extends TestCase
 
     public function provideValidatePath()
     {
-        return array(
+        return [
             // absolute paths
-            array('absolute_1', '/foo/bar', true),
-            array('absolute_2', 'foo/bar', true),
-            array('absolute_3', 'foo', true),
+            ['absolute_1', '/foo/bar', true],
+            ['absolute_2', 'foo/bar', true],
+            ['absolute_3', 'foo', true],
 
             // valid normal paths
-            array('normal_1', '../foo/bar', false),
-            array('normal_2', '.../foo/bar', false),
-            array('normal_3', 'foo ', false),
-            array('normal_4', 'foo/', false),
-            array('normal_5', 'foo/bar[2]', false),
-            array('normal_6', 'foo[1]/bar[2]', false),
-            array('normal_7', '12345/6789', false),
-            array('normal_8', 'foo:bar/bar:foo', false),
-            array('normal_9', 'foo:!bar/bar:foo', false),
-            array('normal_10', ' /foo', false),
-            array('normal_11', '[]foo', false),
-            array('normal_12', '    ', false),
-            array('normal_13', '/', false),
-            array('normal_14', '!foo:!bar/bar:foo', false),
-        );
+            ['normal_1', '../foo/bar', false],
+            ['normal_2', '.../foo/bar', false],
+            ['normal_3', 'foo ', false],
+            ['normal_4', 'foo/', false],
+            ['normal_5', 'foo/bar[2]', false],
+            ['normal_6', 'foo[1]/bar[2]', false],
+            ['normal_7', '12345/6789', false],
+            ['normal_8', 'foo:bar/bar:foo', false],
+            ['normal_9', 'foo:!bar/bar:foo', false],
+            ['normal_10', ' /foo', false],
+            ['normal_11', '[]foo', false],
+            ['normal_12', '    ', false],
+            ['normal_13', '/', false],
+            ['normal_14', '!foo:!bar/bar:foo', false],
+        ];
     }
 
     /**
@@ -49,7 +49,7 @@ abstract class PathValidatorTestCase extends TestCase
         $pathAnswers = $this->getPathAnswers();
 
         if (!isset($pathAnswers[$key])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Validator test class "%s" did not provide an answer for path "%s" with key "%s"',
                 get_class($this),
                 $path,
@@ -60,7 +60,7 @@ abstract class PathValidatorTestCase extends TestCase
         $isValid = $pathAnswers[$key];
 
         if (false === $isValid) {
-            $this->setExpectedException('PHPCR\ValueFormatException');
+            $this->expectException(ValueFormatException::class);
         }
 
         if ($absolute) {
@@ -72,32 +72,32 @@ abstract class PathValidatorTestCase extends TestCase
 
     public function provideValidateName()
     {
-        return array(
-            array('normal_1', 'this is invalid:foobar'),
-            array('normal_2', '/this/is/a/path'), // path charaters
-            array('normal_3', 'this:is valid'),
-            array('normal_4', 'Thisisvalidtoo!'),
-            array('normal_5', 'Thisisvalidtoo!:foobar'), // ! not allowed in namespace
-            array('normal_6', 'this is something'),
+        return [
+            ['normal_1', 'this is invalid:foobar'],
+            ['normal_2', '/this/is/a/path'], // path charaters
+            ['normal_3', 'this:is valid'],
+            ['normal_4', 'Thisisvalidtoo!'],
+            ['normal_5', 'Thisisvalidtoo!:foobar'], // ! not allowed in namespace
+            ['normal_6', 'this is something'],
 
             // strange characters in namespace
-            array('namespace_1', $this->translateCharFromCode('\uD7FF').':foo'),
-            array('namespace_2', $this->translateCharFromCode('\uFFFD').':foo'),
-            array('namespace_3', $this->translateCharFromCode('\u10000').':foo'),
-            array('namespace_4', $this->translateCharFromCode('\u10FFFF').':foo'),
-            array('namespace_5', $this->translateCharFromCode('\u0001').':foo'),
-            array('namespace_6', $this->translateCharFromCode('\u0002').':foo'),
-            array('namespace_7', $this->translateCharFromCode('\u0003').':foo'),
-            array('namespace_8', $this->translateCharFromCode('\u0008').':foo'),
-            array('namespace_9', $this->translateCharFromCode('\uFFFF').':foo'),
+            ['namespace_1', $this->translateCharFromCode('\uD7FF').':foo'],
+            ['namespace_2', $this->translateCharFromCode('\uFFFD').':foo'],
+            ['namespace_3', $this->translateCharFromCode('\u10000').':foo'],
+            ['namespace_4', $this->translateCharFromCode('\u10FFFF').':foo'],
+            ['namespace_5', $this->translateCharFromCode('\u0001').':foo'],
+            ['namespace_6', $this->translateCharFromCode('\u0002').':foo'],
+            ['namespace_7', $this->translateCharFromCode('\u0003').':foo'],
+            ['namespace_8', $this->translateCharFromCode('\u0008').':foo'],
+            ['namespace_9', $this->translateCharFromCode('\uFFFF').':foo'],
 
             // strange characters in name
-            array('localname_1', 'foo:' . $this->translateCharFromCode('\u0001')),
-            array('localname_2', 'foo:' . $this->translateCharFromCode('\u0002')),
-            array('localname_3', 'foo:' . $this->translateCharFromCode('\u0003')),
-            array('localname_4', 'foo:' . $this->translateCharFromCode('\u0008')),
-            array('localname_5', 'foo:' . $this->translateCharFromCode('\uFFFD')),
-        );
+            ['localname_1', 'foo:' . $this->translateCharFromCode('\u0001')],
+            ['localname_2', 'foo:' . $this->translateCharFromCode('\u0002')],
+            ['localname_3', 'foo:' . $this->translateCharFromCode('\u0003')],
+            ['localname_4', 'foo:' . $this->translateCharFromCode('\u0008')],
+            ['localname_5', 'foo:' . $this->translateCharFromCode('\uFFFD')],
+        ];
     }
 
     /**
@@ -108,7 +108,7 @@ abstract class PathValidatorTestCase extends TestCase
         $nameAnswers = $this->getNameAnswers();
 
         if (!isset($nameAnswers[$key])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Validator test class "%s" did not provide an answer for name "%s" with key "%s"',
                 get_class($this),
                 $name,
@@ -119,7 +119,7 @@ abstract class PathValidatorTestCase extends TestCase
         $isValid = $nameAnswers[$key];
 
         if (false === $isValid) {
-            $this->setExpectedException('PHPCR\ValueFormatException');
+            $this->expectException(ValueFormatException::class);
         }
 
         $this->getValidator()->validateName($name);
@@ -132,21 +132,22 @@ abstract class PathValidatorTestCase extends TestCase
 
     public function provideDestPath()
     {
-        return array(
-            array('/path/to[0]', false),
-            array('path/to/something', false),
-            array('', false),
-            array('/path/to/this', true),
-        );
+        return [
+            ['/path/to[0]', false],
+            ['path/to/something', false],
+            ['', false],
+            ['/path/to/this', true],
+        ];
     }
 
     /**
      * @dataProvider provideDestPath
+     * @throws \PHPUnit_Framework_Exception
      */
     public function testDestPath($path, $isValid)
     {
         if (false === $isValid) {
-            $this->setExpectedException('Jackalope\Validation\Exception\InvalidPathException');
+            $this->expectException(InvalidPathException::class);
         }
 
         $this->getValidator()->validateDestPath($path);

--- a/tests/Jackalope/WorkspaceTest.php
+++ b/tests/Jackalope/WorkspaceTest.php
@@ -2,20 +2,39 @@
 
 namespace Jackalope;
 
+use Jackalope\NodeType\NodeTypeManager;
+use Jackalope\Transport\TransportInterface;
+use PHPCR\SessionInterface;
+
 class WorkspaceTest extends TestCase
 {
+    /**
+     * @var string
+     */
     private $name = 'a3lkjas';
+
+    /**
+     * @var FactoryInterface
+     */
     private $factory;
+
+    /**
+     * @var SessionInterface
+     */
     private $session;
+
+    /**
+     * @var ObjectManager
+     */
     private $om;
 
     public function setUp()
     {
         $this->factory = new Factory;
 
-        $transport = $this->getMockBuilder('Jackalope\Transport\TransportInterface')
+        $transport = $this->getMockBuilder(TransportInterface::class)
             ->disableOriginalConstructor()
-            ->getMock(array())
+            ->getMock([])
         ;
 
         $this->session = $this->getSessionMock();
@@ -38,6 +57,6 @@ class WorkspaceTest extends TestCase
         $w = new Workspace($this->factory, $this->session, $this->om, $this->name);
 
         $ntm = $w->getNodeTypeManager();
-        $this->assertInstanceOf('Jackalope\NodeType\NodeTypeManager', $ntm);
+        $this->assertInstanceOf(NodeTypeManager::class, $ntm);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,4 @@ if (!$loader = @include __DIR__.'/../vendor/autoload.php') {
         'php composer.phar install'.PHP_EOL);
 }
 
-$loader->add('Jackalope', array(
-    'tests'
-));
+$loader->add('Jackalope', ['tests']);


### PR DESCRIPTION
php 5.4 short array syntax
:: clas names
php 5.6+ compatibility
removed deprecations from tests
updated travis to php 5.6+
added modern phpunit to dev dependencies

I tested it with jackalope-dbal and tests fails only on https://github.com/jackalope/jackalope/issues/326 so I think all tests work.