### PR TITLE
Handle root node replacement correctly

### DIFF
--- a/src/Jackalope/ImportExport/ImportExport.php
+++ b/src/Jackalope/ImportExport/ImportExport.php
@@ -292,8 +292,11 @@ class ImportExport implements ImportUUIDBehaviorInterface
             } elseif ('jcr:created' === $name || 'jcr:createdBy' === $name) {
                 // skip PROTECTED properties. TODO: get the names from node type instead of hardcode
             } elseif ('jcr:uuid' === $name) {
-                //avoid to throw an exception when trying to set a UUID when importing from XML
-                $node->setProperty($name, $info['values'], $info['type'], false);
+                // The root node is not removed and thus UUID needs not be updated
+                if (0 !== $node->getDepth()) {
+                    // Set the UUID on this node. Validate false to allow setting the UUID manually.
+                    $node->setProperty($name, $info['values'], $info['type'], false);
+                }
             } else {
                 $node->setProperty($name, $info['values'], $info['type']);
             }

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -551,8 +551,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
-     * @param boolean $validate does the NodeType control throw an exception if
-     *      the property can't be set? To use in case of UUID import
+     * @param boolean $validate When false, node types are not asked to validate
+     *                          whether operation is allowed
      *
      * @throws InvalidItemStateException
      * @throws NamespaceException

--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -1873,7 +1873,7 @@ class ObjectManager
      */
     public function registerUuid($uuid, $absPath)
     {
-        if (isset($this->objectsByUuid[$uuid])) {
+        if (array_key_exists($uuid, $this->objectsByUuid)) {
             throw new RuntimeException(sprintf(
                 'Object path for UUID "%s" has already been registered to "%s"',
                 $uuid, $this->objectsByUuid[$uuid]


### PR DESCRIPTION
Fixes #326 

- Allow forcing the registration of a UUID via. a flag.
- To allow the UUID_REPLACE_EXISTING flag to be used when importing
data.

--

- Is it valid to register a UUID with a different node path?

I wonder if it is better to "ask" the object manager first, if it has a UUID (optionally with a path), and then register it if required.