### PR TITLE
Fixed fallback-definition to return important defintion first

### DIFF
--- a/src/Jackalope/Item.php
+++ b/src/Jackalope/Item.php
@@ -579,7 +579,7 @@ abstract class Item implements ItemInterface
                 if ($candidate->getName() === $this->name) {
                     return $candidate;
                 }
-                if ('*' === $candidate->getName()) {
+                if (!$fallbackDefinition && '*' === $candidate->getName()) {
                     // if we have multiple wildcard definitions, they are hopefully equivalent
                     $fallbackDefinition = $candidate;
                     // do not abort loop, in case we hit an exactly matching definition


### PR DESCRIPTION
When receiving `NodeDefinitions` from a node which has the `nt:unstructured` as primary-type. The resulting definition is always the `nt:unstructured` definition.

Also if the node would match multiple definitions in the chain (because of matching the wildcard).

The comment in the line 541 describes also my problem. But my definitions defer in the "OnParentVersionAction" which is quite important for our usecase in sulu.