### PR TITLE
return early from Node::setProperty when value does not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 CHANGELOG
 =========
 
+1.3.1
+-----
+
+* bugfix #332 return early from Node::setProperty when value does not change. This avoids regressions with #307.
+
 1.3.0
 -----
 
-* feature PHP 7 support
-* bugfix #329 pick most specific property definition on multiple wildcards  
-* bugfix #323 Empty array properties no longer break queries
-* feature #302 Added methods addVersionLabel and removeVersionLabel to VersioningInterface
+* feature PHP 7 support.
+* bugfix #329 pick most specific property definition on multiple wildcards.
+* bugfix #323 Empty array properties no longer break queries.
+* feature #307 register UUID immediately so that getNodeByIdentifier works even before saving the session. 
+* feature #302 Added methods addVersionLabel and removeVersionLabel to VersioningInterface.
 * feature #245 Added NodeProcessor class which can be used by implementations to validate and process nodes.
-* bugfix #229 Userland node type filtering does not work
+* bugfix #229 Userland node type filtering does not work.

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -566,6 +566,12 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     {
         $this->checkState();
 
+        // abort early when the node value is not changed
+        // for multivalue, === is only true when array keys and values match. this is exactly what we need.
+        if (array_key_exists($name, $this->properties) && $this->properties[$name]->getValue() === $value) {
+            return $this->properties[$name];
+        }
+
         if ($validate && 'jcr:uuid' === $name && !$this->isNodeType('mix:referenceable')) {
             throw new ConstraintViolationException('You can only change the uuid of newly created nodes that have "referenceable" mixin.');
         }
@@ -630,7 +636,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
         // if the property is the UUID, then register the UUID against the path
         // of this node.
-        if ($name === 'jcr:uuid') {
+        if ('jcr:uuid' === $name) {
             $this->objectManager->registerUuid($value, $this->getPath());
         }
 


### PR DESCRIPTION
#307 was a tricky beast. the current setup fails for phpcr-odm because we register the uuid on adding the mixin and later map the uuid field in the list of mapped fields again. while that is not strictly correct of phpcr-odm, it shows that there are unnecessary regressions if we no longer allow that.