### PR TITLE
Fix typo in DebugStack

### DIFF
--- a/src/Jackalope/Transport/Logging/DebugStack.php
+++ b/src/Jackalope/Transport/Logging/DebugStack.php
@@ -79,7 +79,7 @@ class DebugStack implements LoggerInterface
     /**
      * Return a simple backtrace showing, for each caller, the class, function and line number.
      *
-     * @retrun array
+     * @return array
      */
     private function getBacktrace()
     {


### PR DESCRIPTION
This typo summons Doctrine annotation reader for search nonexistent "retrun" annotation, which produce error:
[Semantical Error] The annotation "@retrun" in method Jackalope\Transport\Logging\DebugStack::getBacktrace() was never imported. Did you maybe forget to add a "use" statement for this annotation?