### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpcr/phpcr-implementation": "2.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7 || ^6.4"
     },
     "autoload": {
         "psr-0": { "Jackalope\\": "src/" }

--- a/tests/Jackalope/PropertyTest.php
+++ b/tests/Jackalope/PropertyTest.php
@@ -73,14 +73,14 @@ class PropertyTest extends TestCase
         $this->assertSame(\PHPCR_PropertyType::UNDEFINED, $val->getType());
         $val = new Value('String', '');
         $this->assertSame(\PHPCR_PropertyType::STRING, $val->getType());
-        $this->setExpectedException('\Jackalope\NotImplementedException');
+        $this->expectException('\Jackalope\NotImplementedException');
         $val = new Value('Binary', '');
         // $this->assertSame(\PHPCR_PropertyType::BINARY, $val->getType());
         $val = new Value('Long', '');
         $this->assertSame(\PHPCR_PropertyType::LONG, $val->getType());
         $val = new Value('Double', '');
         $this->assertSame(\PHPCR_PropertyType::DOUBLE, $val->getType());
-        $this->setExpectedException('\Jackalope\NotImplementedException');
+        $this->expectException('\Jackalope\NotImplementedException');
         $val = new Value('Date', '');
         // $this->assertSame(\PHPCR_PropertyType::DATE, $val->getType());
         $val = new Value('Boolean', '');
@@ -97,7 +97,7 @@ class PropertyTest extends TestCase
         $this->assertSame(\PHPCR_PropertyType::URI, $val->getType());
         $val = new Value('Decimal', '');
         $this->assertSame(\PHPCR_PropertyType::DECIMAL, $val->getType());
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         new Value('InvalidArgument', '');
         */
     }

--- a/tests/Jackalope/Query/QOM/QomToSql1QueryConverterTest.php
+++ b/tests/Jackalope/Query/QOM/QomToSql1QueryConverterTest.php
@@ -8,9 +8,9 @@ use PHPCR\Util\QOM\QueryBuilder;
 use PHPCR\Query\QOM\QueryObjectModelConstantsInterface as Constants;
 use PHPCR\Query\QOM\ConstraintInterface;
 use PHPCR\Query\QOM\SourceInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class QomToSql1QueryConverterTest extends PHPUnit_Framework_TestCase
+class QomToSql1QueryConverterTest extends TestCase
 {
     /**
      * @var QueryObjectModelFactoryInterface

--- a/tests/Jackalope/TestCase.php
+++ b/tests/Jackalope/TestCase.php
@@ -12,10 +12,10 @@ use PHPCR\NodeType\PropertyDefinitionInterface;
 use PHPCR\SimpleCredentials;
 use Jackalope\NodeType\NodeTypeManager;
 use Jackalope\NodeType\NodeTypeXmlConverter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     protected $config;
     protected $credentials;


### PR DESCRIPTION
I've tried to add `PHPUnit 6` support, but the `jackalope/jackalope-transport` dependency didn't allow me to run `composer install`. Should we substitute it?