### PR TITLE
Fix Jackalope\Query\Row create bug

### DIFF
--- a/src/Jackalope/ImportExport/ImportExport.php
+++ b/src/Jackalope/ImportExport/ImportExport.php
@@ -370,6 +370,8 @@ class ImportExport implements ImportUUIDBehaviorInterface
             foreach ($values as $value) {
                 if (PropertyType::BINARY === $property->getType()) {
                     $val = base64_encode($value);
+                } elseif (PropertyType::BOOLEAN === $property->getType()) {
+                    $val = filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';
                 } else {
                     $val = htmlspecialchars($value);
                     //TODO: can we still have invalid characters after this? if so base64 and property, xsi:type="xsd:base64Binary"
@@ -423,6 +425,8 @@ class ImportExport implements ImportUUIDBehaviorInterface
                     continue;
                 }
                 $value = base64_encode($property->getString());
+            } elseif (PropertyType::BOOLEAN === $property->getType()) {
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';
             } else {
                 $value = htmlspecialchars($property->getString());
             }
@@ -561,7 +565,13 @@ class ImportExport implements ImportUUIDBehaviorInterface
                         // this is an empty tag
                         $values[] = '';
                     } else {
-                        $values[] = (PropertyType::BINARY === $type) ? base64_decode($xml->value) : $xml->value;
+                        if (PropertyType::BINARY === $type) {
+                            $values[] = base64_decode($xml->value);
+                        } elseif (PropertyType::BOOLEAN === $type) {
+                            $values[] = filter_var($xml->value, FILTER_VALIDATE_BOOLEAN);
+                        } else {
+                            $values[] = $xml->value;
+                        }
                         $xml->read(); // consume the content
                     }
                 }

--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -107,7 +107,7 @@ class Row implements Iterator, RowInterface
                 $this->path[$selectorName] = $column['dcr:value'];
             } else {
                 if ('jcr:primaryType' === substr($column['dcr:name'], -15)) {
-                    $this->defaultSelectorName = $selectorName;
+                    $this->defaultSelectorName = $column['dcr:value'];
                 }
                 $this->columns[] = $column;
                 $this->values[$selectorName][$column['dcr:name']] = $column['dcr:value'];


### PR DESCRIPTION
The following code

```php
...
$ws = $session->getWorkspace();
$qm = $ws->getQueryManager();

$result = $qm->createQuery(
  "SELECT [jcr:primaryType] FROM [rep:root]",
  "JCR-SQL2"
)
->execute();

foreach ($result as $row) {
  echo $row->getValue("jcr:primaryType") . "\n";
}
```
throws
```
[PHPCR\ItemNotFoundException]
Column '.jcr:primaryType' not found
```