### PR TITLE
Fixed typo in ObjectManager PHPDoc

### DIFF
--- a/src/Jackalope/ObjectManager.php
+++ b/src/Jackalope/ObjectManager.php
@@ -1613,7 +1613,7 @@ class ObjectManager
      *
      * @throws RepositoryException if the transaction implementation
      *      encounters an unexpected error condition.
-     * @throws |InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function beginTransaction()
     {


### PR DESCRIPTION
This erroneous pipe is currently crashing psalm in my setup.