### PR TITLE
Avoid deprecation message for getIterator ReturnTypeWillChange

### DIFF
--- a/src/Jackalope/Lock/LockManager.php
+++ b/src/Jackalope/Lock/LockManager.php
@@ -77,6 +77,7 @@ class LockManager implements IteratorAggregate, LockManagerInterface
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->getLockTokens());

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -1681,6 +1681,7 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      *
      * @throws RepositoryException
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $this->checkState();

--- a/src/Jackalope/Observation/ObservationManager.php
+++ b/src/Jackalope/Observation/ObservationManager.php
@@ -119,6 +119,7 @@ class ObservationManager implements IteratorAggregate, ObservationManagerInterfa
      *
      * @see getRegisteredEventListeners
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getRegisteredEventListeners();

--- a/src/Jackalope/Property.php
+++ b/src/Jackalope/Property.php
@@ -621,6 +621,7 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
      * @throws RepositoryException
      * @throws ValueFormatException
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $this->checkState();

--- a/src/Jackalope/Query/QueryResult.php
+++ b/src/Jackalope/Query/QueryResult.php
@@ -67,6 +67,7 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
      *
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getRows();


### PR DESCRIPTION
Currenty working on getting phpcr-shell to symfony 6 and did stumble over \ReturnTypeWillChange deprecations again.