### PR TITLE
Added return annotations to many methods that implement PHPCR interfaces

### DIFF
--- a/src/Jackalope/Item.php
+++ b/src/Jackalope/Item.php
@@ -218,6 +218,8 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the normalized absolute path of this Item
+     *
      * @api
      */
     public function getPath()
@@ -230,6 +232,9 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the name of this Item in qualified form or an empty
+     *                string if this Item is the root node of a workspace
+     *
      * @api
      */
     public function getName()
@@ -241,6 +246,8 @@ abstract class Item implements ItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ItemInterface the ancestor of this Item at the specified depth
      *
      * @api
      */
@@ -263,6 +270,8 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeInterface the parent of this Item
+     *
      * @api
      */
     public function getParent()
@@ -279,6 +288,8 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return int the depth of this Item in the workspace item graph
+     *
      * @api
      */
     public function getDepth()
@@ -290,6 +301,8 @@ abstract class Item implements ItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return SessionInterface the Session through which this Item was acquired
      *
      * @api
      */
@@ -303,6 +316,8 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if this Item is a Node, false if it is a Property
+     *
      * @api
      */
     public function isNode()
@@ -315,6 +330,8 @@ abstract class Item implements ItemInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if this item is new; false otherwise
+     *
      * @api
      */
     public function isNew()
@@ -324,6 +341,8 @@ abstract class Item implements ItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true if this item is modified; false otherwise
      *
      * @api
      */
@@ -335,6 +354,8 @@ abstract class Item implements ItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool
      *
      * @private
      */
@@ -387,6 +408,9 @@ abstract class Item implements ItemInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true if this Item object and otherItem represent the
+     *              same actual repository item; false otherwise
      *
      * @api
      */

--- a/src/Jackalope/NamespaceRegistry.php
+++ b/src/Jackalope/NamespaceRegistry.php
@@ -90,6 +90,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @api
      */
     public function registerNamespace($prefix, $uri)
@@ -124,6 +126,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @api
      */
     public function unregisterNamespaceByURI($uri)
@@ -148,6 +152,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getPrefixes()
@@ -163,6 +169,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getURIs()
@@ -177,6 +185,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string a string
      *
      * @api
      */
@@ -195,6 +205,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string a string
      *
      * @api
      */
@@ -256,6 +268,8 @@ class NamespaceRegistry implements IteratorAggregate, NamespaceRegistryInterface
 
     /**
      * Get all defined namespaces
+     *
+     * @return array<string, string> a hashmap of prefix => namespace uri
      *
      * @private
      */

--- a/src/Jackalope/Node.php
+++ b/src/Jackalope/Node.php
@@ -357,6 +357,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      * immediately.
      * Version and Lock related exceptions are delayed until save.
      *
+     * @return NodeInterface the node that was added
+     *
      * @api
      */
     public function addNode($relPath, $primaryNodeTypeName = null)
@@ -439,11 +441,13 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
-     * @api
+     * @return NodeInterface the newly created node
+     *
      * @throws InvalidArgumentException
      * @throws ItemExistsException
      * @throws PathNotFoundException
      * @throws RepositoryException
+     * @api
      */
     public function addNodeAutoNamed($nameHint = null, $primaryNodeTypeName = null)
     {
@@ -554,6 +558,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
      * @param boolean $validate When false, node types are not asked to validate
      *                          whether operation is allowed
      *
+     * @return \PHPCR\PropertyInterface The new resp. updated Property object
+     *
      * @throws InvalidItemStateException
      * @throws NamespaceException
      * @throws \InvalidArgumentException
@@ -650,6 +656,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return NodeInterface the node at relPath
+     *
      * @throws InvalidItemStateException
      *
      * @api
@@ -675,6 +683,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, NodeInterface> over all (matching) child Nodes implementing <b>SeekableIterator</b>
+     *                                          and <b>Countable</b>. Keys are the Node names.
      *
      * @api
      */
@@ -704,6 +715,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string> over all child node names
+     *
      * @api
      */
     public function getNodeNames($nameFilter = null, $typeFilter = null)
@@ -721,6 +734,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\PropertyInterface the property at relPath
      *
      * @throws InvalidItemStateException
      *
@@ -781,6 +796,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return mixed the value of the property with $name
+     *
      * @throws InvalidItemStateException
      * @throws \InvalidArgumentException
      *
@@ -801,6 +818,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return mixed the value of the property at $relPath or $defaultValue
+     *
      * @throws \InvalidArgumentException
      *
      * @throws InvalidItemStateException
@@ -820,6 +839,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, \PHPCR\PropertyInterface> implementing <b>SeekableIterator</b> and
+     *                                                     <b>Countable</b>. Keys are the property names.
      *
      * @api
      */
@@ -842,6 +864,11 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return array<string, mixed> keys are the property names, values the corresponding
+     *                              property value (or array of values in case of multi-valued properties)
+     *                              If $dereference is false, reference properties are uuid strings and
+     *                              path properties path strings instead of the referenced node instances
      *
      * @throws \InvalidArgumentException
      * @throws InvalidItemStateException
@@ -880,6 +907,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return ItemInterface the primary child item
+     *
      * @api
      */
     public function getPrimaryItem()
@@ -913,6 +942,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the identifier of this node
+     *
      * @throws \InvalidArgumentException
      *
      * @throws AccessDeniedException
@@ -945,6 +976,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return int the index of this node within the ordered set of its
+     *             same-name sibling nodes
+     *
      * @api
      */
     public function getIndex()
@@ -956,6 +990,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, \PHPCR\PropertyInterface> implementing <b>SeekableIterator</b> and
+     *                                                     <b>Countable</b>. Keys are the property names.
      *
      * @api
      */
@@ -969,6 +1006,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, \PHPCR\PropertyInterface> implementing <b>SeekableIterator</b> and
+     *                                                     <b>Countable</b>. Keys are the property names.
      * @api
      */
     public function getWeakReferences($name = null)
@@ -980,6 +1019,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true if a node exists at relPath; false otherwise
      *
      * @api
      */
@@ -1001,6 +1042,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if a property exists at relPath; false otherwise
+     *
      * @api
      */
     public function hasProperty($relPath)
@@ -1020,6 +1063,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if this node has one or more child nodes; false
+     *              otherwise
+     *
      * @api
      */
     public function hasNodes()
@@ -1032,6 +1078,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if this node has one or more properties; false
+     *              otherwise
+     *
      * @api
      */
     public function hasProperties()
@@ -1043,6 +1092,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return NodeTypeInterface a NodeType object
      *
      * @api
      */
@@ -1057,6 +1108,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return NodeTypeInterface[] an array of mixin node types
      *
      * @api
      */
@@ -1081,6 +1134,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if this node is of the specified primary node type
+     *               or mixin type, or a subtype thereof. Returns false otherwise.
      * @api
      */
     public function isNodeType($nodeTypeName)
@@ -1248,6 +1303,9 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if the specified mixin node type, mixinName, can be
+     *              added to this node; false otherwise
+     *
      * @throws InvalidItemStateException
      *
      * @api
@@ -1261,6 +1319,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return NodeDefinitionInterface a NodeDefinition object
      *
      * @api
      */
@@ -1303,6 +1363,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the absolute path to the corresponding node
+     *
      * @throws InvalidItemStateException
      *
      * @api
@@ -1319,6 +1381,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeInterface> implementing <b>SeekableIterator</b> and
+     *                                          <b>Countable</b>. Keys are the Node names.
      * @api
      */
     public function getSharedSet()
@@ -1330,6 +1394,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return void
      *
      * @throws InvalidItemStateException
      *
@@ -1361,6 +1427,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool
+     *
      * @api
      */
     public function isCheckedOut()
@@ -1375,6 +1443,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool
      *
      * @api
      */
@@ -1402,6 +1472,8 @@ class Node extends Item implements IteratorAggregate, NodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @throws InvalidItemStateException
      *

--- a/src/Jackalope/NodeType/ItemDefinition.php
+++ b/src/Jackalope/NodeType/ItemDefinition.php
@@ -108,6 +108,8 @@ class ItemDefinition implements ItemDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\NodeTypeInterface a NodeType object
+     *
      * @throws NoSuchNodeTypeException
      * @throws RepositoryException
      *
@@ -121,6 +123,8 @@ class ItemDefinition implements ItemDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return string a string denoting the name or "*"
+     *
      * @api
      */
     public function getName()
@@ -130,6 +134,9 @@ class ItemDefinition implements ItemDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if the item is automatically created when its
+     *              parent node is created, else false
      *
      * @api
      */
@@ -141,6 +148,8 @@ class ItemDefinition implements ItemDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if the item is mandatory, else false
+     *
      * @api
      */
     public function isMandatory()
@@ -151,6 +160,8 @@ class ItemDefinition implements ItemDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return int an int constant member of OnParentVersionAction
+     *
      * @api
      */
     public function getOnParentVersion()
@@ -160,6 +171,8 @@ class ItemDefinition implements ItemDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if the child item is protected, else false
      *
      * @api
      */

--- a/src/Jackalope/NodeType/NodeDefinition.php
+++ b/src/Jackalope/NodeType/NodeDefinition.php
@@ -59,6 +59,8 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\NodeTypeInterface[] an array of NodeType objects
+     *
      * @api
      */
     public function getRequiredPrimaryTypes()
@@ -76,6 +78,8 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getRequiredPrimaryTypeNames()
@@ -85,6 +89,8 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeType\NodeTypeInterface a NodeType
      *
      * @api
      */
@@ -100,6 +106,8 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the name of the default primary type
+     *
      * @api
      */
     public function getDefaultPrimaryTypeName()
@@ -109,6 +117,8 @@ class NodeDefinition extends ItemDefinition implements NodeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if the node my have a same-name sibling, else false
      *
      * @api
      */

--- a/src/Jackalope/NodeType/NodeType.php
+++ b/src/Jackalope/NodeType/NodeType.php
@@ -66,6 +66,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return NodeTypeInterface[] all parent NodeTypes
+     *
      * @api
      */
     public function getSupertypes()
@@ -84,6 +86,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getSupertypeNames()
@@ -100,6 +104,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return NodeTypeInterface[] the direct parents of this type
      *
      * @api
      */
@@ -118,6 +124,9 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeTypeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                               Keys are the node type names.
+     *
      * @api
      */
     public function getSubtypes()
@@ -128,6 +137,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeTypeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                               Keys are the node type names.
      * @api
      */
     public function getDeclaredSubtypes()
@@ -138,6 +149,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool
+     *
      * @api
      */
     public function isNodeType($nodeTypeName)
@@ -147,6 +160,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeType\PropertyDefinitionInterface[]
      *
      * @api
      */
@@ -165,6 +180,8 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\NodeDefinitionInterface[]
+     *
      * @api
      */
     public function getChildNodeDefinitions()
@@ -181,6 +198,9 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true if setting propertyName to value is allowed by this
+     *               node type, else false
      *
      * @throws ValueFormatException
      * @throws ConstraintViolationException
@@ -274,6 +294,9 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if the node type allows the addition of a child
+     *              node, else false
+     *
      * @throws ConstraintViolationException
      *
      * @api
@@ -337,6 +360,9 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if the node type allows to remove the passed node,
+     *              else false
+     *
      * @throws ConstraintViolationException
      *
      * @api
@@ -366,6 +392,9 @@ class NodeType extends NodeTypeDefinition implements NodeTypeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if the removal of the property is allowed, else
+     *              false
      *
      * @throws ConstraintViolationException
      *

--- a/src/Jackalope/NodeType/NodeTypeDefinition.php
+++ b/src/Jackalope/NodeType/NodeTypeDefinition.php
@@ -181,6 +181,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the name of the node type
+     *
      * @api
      */
     public function getName()
@@ -190,6 +192,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @api
      */
@@ -205,6 +209,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if the current type is abstract, else false
+     *
      * @api
      */
     public function isAbstract()
@@ -214,6 +220,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool True if this is a mixin type, else false;
      *
      * @api
      */
@@ -225,6 +233,9 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if nodes of this type must support orderable child
+     *              nodes, else false
+     *
      * @api
      */
     public function hasOrderableChildNodes()
@@ -234,6 +245,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if the node type is queryable, else false
      *
      * @api
      */
@@ -245,6 +258,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the name of the primary item
+     *
      * @api
      */
     public function getPrimaryItemName()
@@ -254,6 +269,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeType\PropertyDefinitionInterface[]
      *
      * @api
      */
@@ -265,6 +282,8 @@ class NodeTypeDefinition implements NodeTypeDefinitionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeType\NodeDefinitionInterface[]
      *
      * @api
      */

--- a/src/Jackalope/NodeType/NodeTypeManager.php
+++ b/src/Jackalope/NodeType/NodeTypeManager.php
@@ -230,6 +230,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return NodeTypeInterface a NodeType object
+     *
      * @api
      */
     public function getNodeType($nodeTypeName)
@@ -264,6 +266,9 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if the node type identified by its name is
+     *              registered, else false
+     *
      * @api
      */
     public function hasNodeType($name)
@@ -282,6 +287,9 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeTypeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                              Keys are the node type names.
+     *
      * @api
      */
     public function getAllNodeTypes()
@@ -293,6 +301,9 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, NodeTypeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                              Keys are the node type names.
      *
      * @api
      */
@@ -306,6 +317,9 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeTypeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                              Keys are the node type names.
+     *
      * @api
      */
     public function getMixinNodeTypes()
@@ -318,6 +332,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\NodeTypeTemplateInterface a NodeTypeTemplate
+     *
      * @api
      */
     public function createNodeTypeTemplate($ntd = null)
@@ -327,6 +343,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeType\NodeDefinitionTemplateInterface a NodeDefinitionTemplate
      *
      * @api
      */
@@ -338,6 +356,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\PropertyDefinitionTemplateInterface an empty
+     *                                              PropertyDefinitionTemplateInterface instance
      * @api
      */
     public function createPropertyDefinitionTemplate()
@@ -347,6 +367,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return NodeTypeInterface the registered node type
      *
      * @api
      */
@@ -380,6 +402,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<string, NodeTypeInterface> over the registered node types implementing <b>SeekableIterator</b>
+     *                                              and <b>Countable</b>. Keys are the node type names.
      * @api
      */
     public function registerNodeTypes(array $definitions, $allowUpdate)
@@ -404,6 +428,9 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, NodeTypeInterface> over the registered node types implementing <b>SeekableIterator</b>
+     *                                              and <b>Countable</b>. Keys are the node type names.
      *
      * @throws AccessDeniedException
      * @throws NamespaceException
@@ -431,6 +458,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @api
      */
     public function unregisterNodeType($name)
@@ -448,6 +477,8 @@ class NodeTypeManager implements IteratorAggregate, NodeTypeManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return void
      *
      * @api
      */

--- a/src/Jackalope/NodeType/PropertyDefinition.php
+++ b/src/Jackalope/NodeType/PropertyDefinition.php
@@ -77,6 +77,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
     /**
      * {@inheritDoc}
      *
+     * @return int an integer constant member of PropertyType
+     *
      * @api
      */
     public function getRequiredType()
@@ -86,6 +88,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @api
      */
@@ -97,6 +101,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
     /**
      * {@inheritDoc}
      *
+     * @return array<mixed>
+     *
      * @api
      */
     public function getDefaultValues()
@@ -106,6 +112,9 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if this property may have multiple values, else
+     *              false
      *
      * @api
      */
@@ -117,6 +126,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
     /**
      * {@inheritDoc}
      *
+     * @return string[] query operator constants as defined in \PHPCR\Query\QueryObjectModelConstantsInterface
+     *
      * @api
      */
     public function getAvailableQueryOperators()
@@ -127,6 +138,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
     /**
      * {@inheritDoc}
      *
+     * @return bool true, if this property is full-text searchable, else false
+     *
      * @api
      */
     public function isFullTextSearchable()
@@ -136,6 +149,8 @@ class PropertyDefinition extends ItemDefinition implements PropertyDefinitionInt
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true, if this property is query orderable, else false
      *
      * @api
      */

--- a/src/Jackalope/Property.php
+++ b/src/Jackalope/Property.php
@@ -209,12 +209,14 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
-     * @api
+     * @return mixed value of this property, or array in case of multi-value
      *
      * @throws InvalidItemStateException
      * @throws ItemNotFoundException
      * @throws RepositoryException
      * @throws ValueFormatException
+     *
+     * @api
      */
     public function getValue()
     {
@@ -260,6 +262,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return string|string[] a string representation of the value of this property, or
+     *                         an array of string for multi-valued properties
      * @throws InvalidItemStateException
      * @throws InvalidArgumentException
      *
@@ -282,6 +286,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return resource|resource[] A stream resource if the underlying binary
      *
      * @throws InvalidArgumentException
      * @throws LogicException
@@ -346,6 +352,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return int|int[] an integer representation of the value of this property,
+     *                   or an array of integer for multi-valued properties
+     *
      * @throws InvalidItemStateException
      * @throws InvalidArgumentException
      *
@@ -365,6 +374,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return float|float[] a float representation of the value of this property, or
+     *                       an array of float for multi-valued properties
+     *
      * @throws InvalidArgumentException
      *
      * @api
@@ -382,6 +394,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string|string[] a string representation of the value of this property, or
+     *                         an array of strings for multi-valued properties
      *
      * @throws InvalidItemStateException
      * @throws InvalidArgumentException
@@ -402,6 +417,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return \DateTime|\DateTime[] a date representation of the value of this property,
+     *                               or an array of DateTime for multi-valued properties
+     *
      * @throws InvalidArgumentException
      *
      * @api
@@ -419,6 +437,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool|bool[] a boolean representation of the value of this property,
+     *                     or an array of boolean for multi-valued properties
      *
      * @throws InvalidArgumentException
      *
@@ -438,6 +459,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeInterface|\PHPCR\NodeInterface[] the referenced Node, or an array of Nodes
+     *                                                     for multi-valued properties
      * @throws InvalidItemStateException
      * @throws NoSuchWorkspaceException
      *
@@ -483,6 +506,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return PropertyInterface|PropertyInterface[] the referenced property, or an array of
+     *                                                properties for multi-valued properties
+     *
      * @throws InvalidItemStateException
      *
      * @api
@@ -511,6 +537,9 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return int|int[] the length of this value, or an array of lengths
+     *                    for multi-valued properties
      *
      * @api
      */
@@ -541,6 +570,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return PropertyDefinitionInterface a PropertyDefinition
+     *                                     object
      * @api
      */
     public function getDefinition()
@@ -559,6 +590,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
     /**
      * {@inheritDoc}
      *
+     * @return int the numerical representation of a property type
+     *
      * @api
      */
     public function getType()
@@ -570,6 +603,8 @@ class Property extends Item implements IteratorAggregate, PropertyInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool true if this property is multi-valued; false otherwise
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/AndConstraint.php
+++ b/src/Jackalope/Query/QOM/AndConstraint.php
@@ -40,6 +40,8 @@ class AndConstraint implements AndInterface
     /**
      * {@inheritDoc}
      *
+     * @return ConstraintInterface the constraint
+     *
      * @api
      */
     public function getConstraint1()
@@ -49,6 +51,8 @@ class AndConstraint implements AndInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ConstraintInterface the constraint
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/Column.php
+++ b/src/Jackalope/Query/QOM/Column.php
@@ -57,6 +57,8 @@ class Column implements ColumnInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the selector name
+     *
      * @api
      */
     public function getSelectorName()
@@ -67,6 +69,9 @@ class Column implements ColumnInterface
     /**
      * {@inheritDoc}
      *
+     * @return string|null the property name, or null to include a column for
+     *                     each single-value non-residual property of the selector's node type
+     *
      * @api
      */
     public function getPropertyName()
@@ -76,6 +81,9 @@ class Column implements ColumnInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string|null the column name; must be null if getPropertyName is
+     *                     null and contain the name for this column otherwise
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/ComparisonConstraint.php
+++ b/src/Jackalope/Query/QOM/ComparisonConstraint.php
@@ -60,6 +60,8 @@ class ComparisonConstraint implements ComparisonInterface
     /**
      * {@inheritDoc}
      *
+     * @return DynamicOperandInterface the operand
+     *
      * @api
      */
     public function getOperand1()
@@ -70,6 +72,8 @@ class ComparisonConstraint implements ComparisonInterface
     /**
      * {@inheritDoc}
      *
+     * @return string one of QueryObjectModelConstantsInterface.JCR_OPERATOR_*
+     *
      * @api
      */
     public function getOperator()
@@ -79,6 +83,8 @@ class ComparisonConstraint implements ComparisonInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return StaticOperandInterface the operand
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/DescendantNodeConstraint.php
+++ b/src/Jackalope/Query/QOM/DescendantNodeConstraint.php
@@ -47,6 +47,8 @@ class DescendantNodeConstraint implements DescendantNodeInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the selector name
+     *
      * @api
      */
     public function getSelectorName()
@@ -56,6 +58,8 @@ class DescendantNodeConstraint implements DescendantNodeInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the path
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/Literal.php
+++ b/src/Jackalope/Query/QOM/Literal.php
@@ -31,6 +31,8 @@ class Literal implements LiteralInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the literal value
+     *
      * @api
      */
     public function getLiteralValue()

--- a/src/Jackalope/Query/QOM/OrConstraint.php
+++ b/src/Jackalope/Query/QOM/OrConstraint.php
@@ -40,6 +40,8 @@ class OrConstraint implements OrInterface
     /**
      * {@inheritDoc}
      *
+     * @return ConstraintInterface the constraint
+     *
      * @api
      */
     public function getConstraint1()
@@ -49,6 +51,8 @@ class OrConstraint implements OrInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ConstraintInterface the constraint
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/Ordering.php
+++ b/src/Jackalope/Query/QOM/Ordering.php
@@ -40,6 +40,8 @@ class Ordering implements OrderingInterface
     /**
      * {@inheritDoc}
      *
+     * @return DynamicOperandInterface the operand
+     *
      * @api
      */
     public function getOperand()
@@ -49,6 +51,9 @@ class Ordering implements OrderingInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string either QueryObjectModelConstants.JCR_ORDER_ASCENDING or
+     *                QueryObjectModelConstants.JCR_ORDER_DESCENDING
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/PropertyValue.php
+++ b/src/Jackalope/Query/QOM/PropertyValue.php
@@ -46,6 +46,8 @@ class PropertyValue implements PropertyValueInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the selector name
+     *
      * @api
      */
     public function getSelectorName()
@@ -55,6 +57,8 @@ class PropertyValue implements PropertyValueInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the property name
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/QueryObjectModel.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModel.php
@@ -91,6 +91,8 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
     /**
      * {@inheritDoc}
      *
+     * @return SourceInterface the node-tuple source
+     *
      * @api
      */
     public function getSource()
@@ -100,6 +102,9 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ConstraintInterface|null the constraint, or null if there is no
+     *                                   constraint
      *
      * @api
      */
@@ -111,6 +116,9 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
     /**
      * {@inheritDoc}
      *
+     * @return OrderingInterface[] an array of the orderings. If no orderings
+     *                              defined an empty array is returned.
+     *
      * @api
      */
     public function getOrderings()
@@ -120,6 +128,9 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ColumnInterface[] an array of the columns to get. If none
+     *                            specified an empty array is returned.
      *
      * @api
      */
@@ -131,6 +142,8 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getBindVariableNames()
@@ -141,6 +154,8 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the query statement
      *
      * @api
      */
@@ -154,6 +169,8 @@ class QueryObjectModel extends SqlQuery implements QueryObjectModelInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the query language
      *
      * @api
      */

--- a/src/Jackalope/Query/QOM/QueryObjectModelFactory.php
+++ b/src/Jackalope/Query/QOM/QueryObjectModelFactory.php
@@ -53,6 +53,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\QueryObjectModelInterface the query
+     *
      * @api
      */
     public function createQuery(
@@ -73,6 +75,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\SelectorInterface the selector
+     *
      * @api
      */
     public function selector($selectorName, $nodeTypeName)
@@ -82,6 +86,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\JoinInterface the join
      *
      * @api
      */
@@ -93,6 +99,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\EquiJoinConditionInterface the constraint
+     *
      * @api
      */
     public function equiJoinCondition($selector1Name, $property1Name, $selector2Name, $property2Name)
@@ -102,6 +110,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\SameNodeJoinConditionInterface the constraint
      *
      * @api
      */
@@ -113,6 +123,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\ChildNodeJoinConditionInterface the constraint
+     *
      * @api
      */
     public function childNodeJoinCondition($childSelectorName, $parentSelectorName)
@@ -122,6 +134,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\DescendantNodeJoinConditionInterface the constraint
      *
      * @api
      */
@@ -133,6 +147,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\AndInterface the And constraint
+     *
      * @api
      */
     public function andConstraint(ConstraintInterface $constraint1, ConstraintInterface $constraint2)
@@ -142,6 +158,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\OrInterface the Or constraint
      *
      * @api
      */
@@ -153,6 +171,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\NotInterface the Not constraint
+     *
      * @api
      */
     public function notConstraint(ConstraintInterface $constraint)
@@ -162,6 +182,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\ComparisonInterface the constraint
      *
      * @api
      */
@@ -173,6 +195,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\PropertyExistenceInterface the constraint
+     *
      * @api
      */
     public function propertyExistence($selectorName, $propertyName)
@@ -182,6 +206,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\FullTextSearchInterface the constraint
      *
      * @throws InvalidArgumentException
      *
@@ -195,6 +221,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\SameNodeInterface the constraint
+     *
      * @api
      */
     public function sameNode($selectorName, $path)
@@ -204,6 +232,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\ChildNodeInterface the constraint
      *
      * @api
      */
@@ -215,6 +245,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\DescendantNodeInterface the constraint
+     *
      * @api
      */
     public function descendantNode($selectorName, $path)
@@ -224,6 +256,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\PropertyValueInterface the operand
      *
      * @throws InvalidArgumentException
      *
@@ -237,6 +271,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\LengthInterface the operand
+     *
      * @api
      */
     public function length(PropertyValueInterface $propertyValue)
@@ -246,6 +282,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\NodeNameInterface the operand
      *
      * @throws InvalidArgumentException
      *
@@ -259,6 +297,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\NodeLocalNameInterface the operand
+     *
      * @api
      */
     public function nodeLocalName($selectorName)
@@ -268,6 +308,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\FullTextSearchScoreInterface the operand
      *
      * @throws InvalidArgumentException
      *
@@ -281,6 +323,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\LowerCaseInterface the operand
+     *
      * @api
      */
     public function lowerCase(DynamicOperandInterface $operand)
@@ -290,6 +334,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\UpperCaseInterface the operand
      *
      * @api
      */
@@ -301,6 +347,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\BindVariableValueInterface the operand
+     *
      * @api
      */
     public function bindVariable($bindVariableName)
@@ -310,6 +358,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return mixed the operand
      *
      * @api
      */
@@ -321,6 +371,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\OrderingInterface the ordering
+     *
      * @api
      */
     public function ascending(DynamicOperandInterface $operand)
@@ -331,6 +383,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\OrderingInterface the ordering
+     *
      * @api
      */
     public function descending(DynamicOperandInterface $operand)
@@ -340,6 +394,8 @@ class QueryObjectModelFactory implements QueryObjectModelFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QOM\ColumnInterface the column
      *
      * @throws \InvalidArgumentException
      *

--- a/src/Jackalope/Query/QOM/Selector.php
+++ b/src/Jackalope/Query/QOM/Selector.php
@@ -45,6 +45,8 @@ class Selector implements SelectorInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the node type name
+     *
      * @api
      */
     public function getNodeTypeName()
@@ -54,6 +56,8 @@ class Selector implements SelectorInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the selector name
      *
      * @api
      */

--- a/src/Jackalope/Query/Query.php
+++ b/src/Jackalope/Query/Query.php
@@ -95,6 +95,8 @@ abstract class Query implements QueryInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QueryResultInterface a QueryResult object
+     *
      * @api
      */
     public function execute()
@@ -113,6 +115,11 @@ abstract class Query implements QueryInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool true if the query was executing and will be cancelled,
+     *              or false if the query cannot not be cancelled because it has either
+     *              already finished executing, it has already been cancelled, or the
+     *              implementation does not support canceling queries
+     *
      * @api
      */
     public function cancel()
@@ -122,6 +129,8 @@ abstract class Query implements QueryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @api
      */
@@ -173,6 +182,8 @@ abstract class Query implements QueryInterface
     /**
      * {@inheritDoc}
      *
+     * @return string the query statement
+     *
      * @api
      */
     public function getStatement()
@@ -182,6 +193,8 @@ abstract class Query implements QueryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string path of the node representing this query
      *
      * @api
      */
@@ -196,6 +209,8 @@ abstract class Query implements QueryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\NodeInterface the newly created node
      *
      * @api
      */

--- a/src/Jackalope/Query/QueryManager.php
+++ b/src/Jackalope/Query/QueryManager.php
@@ -46,6 +46,8 @@ class QueryManager implements QueryManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return QueryInterface a Query object
+     *
      * @api
      */
     public function createQuery($statement, $language)
@@ -71,6 +73,8 @@ class QueryManager implements QueryManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\Query\QOM\QueryObjectModelFactoryInterface a QueryObjectModelFactory object
+     *
      * @api
      */
     public function getQOMFactory()
@@ -81,6 +85,8 @@ class QueryManager implements QueryManagerInterface
     /**
      * {@inheritDoc}
      *
+     * @return QueryInterface a Query object
+     *
      * @api
      */
     public function getQuery($node)
@@ -90,6 +96,8 @@ class QueryManager implements QueryManagerInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @api
      */

--- a/src/Jackalope/Query/QueryResult.php
+++ b/src/Jackalope/Query/QueryResult.php
@@ -75,6 +75,8 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getColumnNames()
@@ -98,6 +100,9 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
     /**
      * {@inheritDoc}
      *
+     * @return \Iterator<\PHPCR\Query\RowInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                 Keys are the row position in this result set
+     *
      * @api
      */
     public function getRows()
@@ -107,6 +112,9 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Iterator<string, \PHPCR\NodeInterface> implementing <b>SeekableIterator</b> and <b>Countable</b>.
+     *                                           Keys are the paths.
      *
      * @api
      */
@@ -127,6 +135,8 @@ class QueryResult implements IteratorAggregate, QueryResultInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string[]
      *
      * @api
      */

--- a/src/Jackalope/Query/Row.php
+++ b/src/Jackalope/Query/Row.php
@@ -124,6 +124,9 @@ class Row implements Iterator, RowInterface
     /**
      * {@inheritDoc}
      *
+     * @return array<string, mixed> hashmap of column name to value of each column of the
+     *                              current result row
+     *
      * @api
      */
     public function getValues()
@@ -140,6 +143,8 @@ class Row implements Iterator, RowInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return mixed the value of the given column of the current result row
      *
      * @api
      */
@@ -174,6 +179,8 @@ class Row implements Iterator, RowInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeInterface|null the result node or null on incomplete outer joins
+     *
      * @api
      */
     public function getNode($selectorName = null)
@@ -189,6 +196,9 @@ class Row implements Iterator, RowInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string|null the path representing the node identified by the given
+     *                      selector or null on incomplete outer joins
      *
      * @api
      */
@@ -208,6 +218,8 @@ class Row implements Iterator, RowInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return float the full text search score for this row
      *
      * @api
      */

--- a/src/Jackalope/Query/RowIterator.php
+++ b/src/Jackalope/Query/RowIterator.php
@@ -53,6 +53,8 @@ class RowIterator implements SeekableIterator, Countable
     /**
      * @param int $position
      *
+     * @return void
+     *
      * @throws OutOfBoundsException
      */
     #[\ReturnTypeWillChange]

--- a/src/Jackalope/Transaction/UserTransaction.php
+++ b/src/Jackalope/Transaction/UserTransaction.php
@@ -77,6 +77,8 @@ class UserTransaction implements UserTransactionInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @api
      */
     public function begin()
@@ -95,6 +97,8 @@ class UserTransaction implements UserTransactionInterface
      * TODO: Make sure RollbackException and AccessDeniedException are thrown
      * by the transport if corresponding problems occur
      *
+     * @return void
+     *
      * @api
      */
     public function commit()
@@ -110,6 +114,8 @@ class UserTransaction implements UserTransactionInterface
     /**
      * {@inheritDoc}
      *
+     * @return bool
+     *
      * @api
      */
     public function inTransaction()
@@ -123,6 +129,8 @@ class UserTransaction implements UserTransactionInterface
      *
      * TODO: Make sure RollbackException and AccessDeniedException are thrown
      * by the transport if corresponding problems occur
+     *
+     * @return void
      *
      * @api
      */
@@ -138,6 +146,8 @@ class UserTransaction implements UserTransactionInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return void
      *
      * @api
      */

--- a/src/Jackalope/Workspace.php
+++ b/src/Jackalope/Workspace.php
@@ -95,6 +95,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\SessionInterface a Session object
+     *
      * @api
      */
     public function getSession()
@@ -104,6 +106,8 @@ class Workspace implements WorkspaceInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return string the name of this workspace
      *
      * @api
      */
@@ -161,6 +165,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return LockManagerInterface
+     *
      * @api
      */
     public function getLockManager()
@@ -185,6 +191,8 @@ class Workspace implements WorkspaceInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\Query\QueryManagerInterface the QueryManager object
      *
      * @api
      */
@@ -219,6 +227,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return UserTransactionInterface a UserTransaction object
+     *
      * @api
      */
     public function getTransactionManager()
@@ -237,6 +247,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NamespaceRegistryInterface the NamespaceRegistry
+     *
      * @api
      */
     public function getNamespaceRegistry()
@@ -251,6 +263,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\NodeType\NodeTypeManagerInterface a NodeTypeManager object
+     *
      * @api
      */
     public function getNodeTypeManager()
@@ -260,6 +274,8 @@ class Workspace implements WorkspaceInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return ObservationManagerInterface an ObservationManager object
      *
      * @api
      */
@@ -285,6 +301,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return \PHPCR\RepositoryManagerInterface
+     *
      * @api
      */
     public function getRepositoryManager()
@@ -294,6 +312,8 @@ class Workspace implements WorkspaceInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \PHPCR\VersionManagerInterface a VersionManager object
      *
      * @api
      */
@@ -309,6 +329,8 @@ class Workspace implements WorkspaceInterface
     /**
      * {@inheritDoc}
      *
+     * @return string[]
+     *
      * @api
      */
     public function getAccessibleWorkspaceNames()
@@ -318,6 +340,8 @@ class Workspace implements WorkspaceInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return void
      *
      * @api
      */


### PR DESCRIPTION
The Symfony deprecation helper reports several deprecation warnings telling that future versions of the PHPCR interfaces may add native return values in the future. This is fixed by the added return annotations.

I'd be happy if this could be merged soon.